### PR TITLE
Fixed import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This library supports all known operations available to libvips found here:
 
 # Installation
 ```bash
-go get -u gopkg.in/davidbyttow/libvips.v1
+go get -u gopkg.in/davidbyttow/govips.v0
 ```
 
 # Example usage


### PR DESCRIPTION
There was obsolete import path via gopkg in readme, with wrong library name and version suffix.