### PR TITLE
Fix repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This library supports all known operations available to libvips found here:
 
 # Installation
 ```bash
-go get -u github.com/davidbyttow/vips
+go get -u github.com/davidbyttow/govips
 ```
 
 # Example usage


### PR DESCRIPTION
The README had the wrong repo name for the installation section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidbyttow/govips/12)
<!-- Reviewable:end -->
