### PR TITLE
Add support for compression and lossless options

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -65,10 +65,11 @@ int save_png_buffer(VipsImage *in, void **buf, size_t *len, int strip, int compr
 	);
 }
 
-int save_webp_buffer(VipsImage *in, void **buf, size_t *len, int strip, int quality) {
+int save_webp_buffer(VipsImage *in, void **buf, size_t *len, int strip, int quality, int lossless) {
 	return vips_webpsave_buffer(in, buf, len,
 		"strip", INT_TO_GBOOLEAN(strip),
 		"Q", quality,
+		"lossless", INT_TO_GBOOLEAN(lossless),
 		NULL
 	);
 }

--- a/bridge.go
+++ b/bridge.go
@@ -138,6 +138,7 @@ func vipsExportBuffer(image *C.VipsImage, params *ExportParams) ([]byte, error) 
 	var cErr C.int
 	interlaced := C.int(boolToInt(params.Interlaced))
 	quality := C.int(params.Quality)
+	lossless := C.int(boolToInt(params.Lossless))
 	stripMetadata := C.int(boolToInt(params.StripMetadata))
 
 	if params.Format != ImageTypeUnknown && !IsTypeSupported(params.Format) {
@@ -155,7 +156,7 @@ func vipsExportBuffer(image *C.VipsImage, params *ExportParams) ([]byte, error) 
 
 	switch params.Format {
 	case ImageTypeWEBP:
-		cErr = C.save_webp_buffer(tmpImage, &ptr, &cLen, stripMetadata, quality)
+		cErr = C.save_webp_buffer(tmpImage, &ptr, &cLen, stripMetadata, quality, lossless)
 	case ImageTypePNG:
 		cErr = C.save_png_buffer(tmpImage, &ptr, &cLen, stripMetadata, C.int(params.Compression), quality, interlaced)
 	case ImageTypeTIFF:

--- a/bridge.h
+++ b/bridge.h
@@ -26,7 +26,7 @@ int find_image_type_saver(int t);
 
 int save_jpeg_buffer(VipsImage* image, void **buf, size_t *len, int strip, int quality, int interlace);
 int save_png_buffer(VipsImage *in, void **buf, size_t *len, int strip, int compression, int quality, int interlace);
-int save_webp_buffer(VipsImage *in, void **buf, size_t *len, int strip, int quality);
+int save_webp_buffer(VipsImage *in, void **buf, size_t *len, int strip, int quality, int lossless);
 int save_tiff_buffer(VipsImage *in, void **buf, size_t *len);
 int load_jpeg_buffer(void *buf, size_t len, VipsImage **out, int shrink);
 

--- a/leak_test.go
+++ b/leak_test.go
@@ -32,16 +32,17 @@ var (
 )
 
 type transform struct {
-	Resize  vips.ResizeStrategy
-	Width   int
-	Height  int
-	Flip    vips.FlipDirection
-	Format  vips.ImageType
-	Zoom    int
-	Blur    float64
-	Kernel  vips.Kernel
-	Interp  vips.Interpolator
-	Quality int
+	Resize      vips.ResizeStrategy
+	Width       int
+	Height      int
+	Flip        vips.FlipDirection
+	Format      vips.ImageType
+	Zoom        int
+	Blur        float64
+	Kernel      vips.Kernel
+	Interp      vips.Interpolator
+	Quality     int
+	Compression int
 }
 
 func TestCleanup(t *testing.T) {
@@ -54,16 +55,17 @@ func TestCleanup(t *testing.T) {
 		for _, size := range sizes {
 			for _, format := range formats {
 				t := transform{
-					Resize:  resize,
-					Width:   size.w,
-					Height:  size.h,
-					Flip:    vips.FlipBoth,
-					Kernel:  vips.KernelLanczos3,
-					Format:  format,
-					Blur:    4,
-					Interp:  vips.InterpolateBicubic,
-					Zoom:    3,
-					Quality: 80,
+					Resize:      resize,
+					Width:       size.w,
+					Height:      size.h,
+					Flip:        vips.FlipBoth,
+					Kernel:      vips.KernelLanczos3,
+					Format:      format,
+					Blur:        4,
+					Interp:      vips.InterpolateBicubic,
+					Zoom:        3,
+					Quality:     80,
+					Compression: 5,
 				}
 				transforms = append(transforms, t)
 			}
@@ -88,6 +90,7 @@ func TestCleanup(t *testing.T) {
 					Interpolator(transform.Interp).
 					Zoom(transform.Zoom, transform.Zoom).
 					Quality(transform.Quality).
+					Compression(transform.Compression).
 					OutputBytes().
 					Apply()
 				require.NoError(t, err)

--- a/transform.go
+++ b/transform.go
@@ -244,6 +244,18 @@ func (t *Transform) Quality(quality int) *Transform {
 	return t
 }
 
+// Compression sets the compression value for image formats that support it
+func (t *Transform) Compression(compression int) *Transform {
+	t.export.Compression = compression
+	return t
+}
+
+// Lossless uses lossless compression for image formats that support both lossy and lossless e.g. webp
+func (t *Transform) Lossless() *Transform {
+	t.export.Lossless = true
+	return t
+}
+
 // StripMetadata strips ICC profile and metadata from the image
 func (t *Transform) StripMetadata() *Transform {
 	t.export.StripProfile = true

--- a/type.go
+++ b/type.go
@@ -28,6 +28,7 @@ type ExportParams struct {
 	Quality         int
 	Compression     int
 	Interlaced      bool
+	Lossless        bool
 	StripProfile    bool
 	StripMetadata   bool
 	Interpretation  Interpretation


### PR DESCRIPTION
Just a small addition to add the option of [Lossless](https://github.com/jcupitt/libvips/blob/master/libvips/foreign/webpsave.c#L367) compression for webp images.

While I was in there I also surfaced the `Compression(int)` option you'd added but which wasn't available through `Transform`.

I've had a test of these in my project and they both seem to be functioning ok, but I was having some issues getting your tests running locally so if you could give it the once over.

Let me know if you'd like any other tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidbyttow/govips/19)
<!-- Reviewable:end -->
