### PR TITLE
fix timing of getting operation object pointer

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -46,8 +46,8 @@ func vipsCallOperation(operation *C.VipsOperation, options []*Option) error {
 	if ret := C.vips_cache_operation_buildp(&operation); ret != 0 {
 		return handleVipsError()
 	}
-  
-  defer C.g_object_unref(C.gpointer(unsafe.Pointer(operation)))
+
+	defer C.g_object_unref(C.gpointer(unsafe.Pointer(operation)))
 
 	// Write back the outputs
 	for _, option := range options {

--- a/bridge.go
+++ b/bridge.go
@@ -30,8 +30,6 @@ func vipsCall(name string, options []*Option) error {
 }
 
 func vipsCallOperation(operation *C.VipsOperation, options []*Option) error {
-	defer C.g_object_unref(C.gpointer(unsafe.Pointer(operation)))
-
 	// Set the inputs
 	for _, option := range options {
 		if option.Output() {
@@ -48,6 +46,8 @@ func vipsCallOperation(operation *C.VipsOperation, options []*Option) error {
 	if ret := C.vips_cache_operation_buildp(&operation); ret != 0 {
 		return handleVipsError()
 	}
+  
+  defer C.g_object_unref(C.gpointer(unsafe.Pointer(operation)))
 
 	// Write back the outputs
 	for _, option := range options {


### PR DESCRIPTION
I fixed timing of getting operation object pointer that must decreases the reference count.

Because,  when we run the same operation with parameter **more than once**, it will be outputted `GLib-GObject-CRITICAL **: g_object_unref: assertion 'G_IS_OBJECT (object)' failed` 

The cause is , as follows URL, if we get a hit in cache, operation object pointer is change.

https://jcupitt.github.io/libvips/API/current/VipsOperation.html#vips-cache-operation-buildp

```
Look up operation in the cache. If we get a hit, unref operation , ref the old one and return that through the argument pointer.

If we miss, build and add operation .
```

I'm sorry in poor English...
Thank you.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidbyttow/govips/24)
<!-- Reviewable:end -->
