### PR TITLE
fix a memory leak in vipsExportBuffer

### DIFF
--- a/pkg/vips/bridge.go
+++ b/pkg/vips/bridge.go
@@ -136,7 +136,9 @@ func vipsExportBuffer(image *C.VipsImage, params *ExportParams) ([]byte, ImageTy
 	// If these are equal, then we don't want to deref the original image as
 	// the original will be returned if the target colorspace is not supported
 	if tmpImage != image {
-		defer C.g_object_unref(C.gpointer(tmpImage))
+		defer func() {
+			C.g_object_unref(C.gpointer(tmpImage))
+		}()
 	}
 
 	cLen := C.size_t(0)


### PR DESCRIPTION
Hi there,

The variable `tmpImage` will be replaced at line https://github.com/davidbyttow/govips/blob/master/pkg/vips/bridge.go#L155. 

But the `defer` statement captured the original value at line https://github.com/davidbyttow/govips/blob/master/pkg/vips/bridge.go#L130.

So if we flatten the background color on an image, this will cause a memory leak.

Reference:

- https://golang.org/ref/spec#Defer_statements

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/davidbyttow/govips/33)
<!-- Reviewable:end -->
