### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,20 @@ before_script:
 #  - go get -u github.com/golang/lint/golint
 
 script:
-  - diff -u <(echo -n) <(gofmt -s -d ./)
-  - diff -u <(echo -n) <(go vet ./)
+  - |
+    set -e
+    diff -u <(echo -n) <(gofmt -s -d ./)
+  - |
+    set -e
+    diff -u <(echo -n) <(go vet ./pkg/vips)
 #  - diff -u <(echo -n) <(golint ./)
-  - go test -short -v -race -covermode=atomic -coverprofile=coverage.out
+  - |
+    set -e
+    for test in ./pkg/vips/*_test.go
+    do
+      echo $test
+      go test $test -short -v -race -covermode=atomic -coverprofile=coverage.out
+    done
 
 after_success:
   - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,3 @@ script:
       echo $test
       go test $test -short -v -race -covermode=atomic -coverprofile=coverage.out
     done
-
-after_success:
-  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
     cd ../..
 
 before_script:
-#  - go get -u github.com/golang/lint/golint
+  - go get -u github.com/golang/lint/golint
 
 script:
   - |
@@ -64,7 +64,9 @@ script:
   - |
     set -e
     diff -u <(echo -n) <(go vet ./pkg/vips)
-#  - diff -u <(echo -n) <(golint ./)
+  - |
+    set -e
+    diff -u <(echo -n) <(golint ./)
   - |
     set -e
     for test in ./pkg/vips/*_test.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ matrix:
     - env: VIPS_VERSION=8.2
     - env: VIPS_VERSION=8.3
 
-cache: apt
+cache:
+  apt: true
+  directories:
+    - libvips
 
 addons:
   apt:
@@ -35,27 +38,21 @@ addons:
 
 # VIPS 8.3.3 requires Poppler 0.30 which is not released on Trusty.
 before_install:
-  - wget https://github.com/jcupitt/libvips/archive/v${VIPS_VERSION}.zip
-  - unzip v${VIPS_VERSION}
-  - cd libvips-${VIPS_VERSION}
-  - test -f autogen.sh && ./autogen.sh || ./bootstrap.sh
-  - >
-    CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0
-    ./configure
-    --disable-debug
-    --disable-dependency-tracking
-    --disable-introspection
-    --disable-static
-    --enable-gtk-doc-html=no
-    --enable-gtk-doc=no
-    --enable-pyvips8=no
-    --without-orc
-    --without-python
-    $1
-  - make
-  - sudo make install
-  - sudo ldconfig
-  - cd ..
+  - |
+    cd libvips
+    test -d libvips-${VIPS_VERSION} && {
+      cd libvips-${VIPS_VERSION}
+    } || {
+      wget https://github.com/jcupitt/libvips/archive/v${VIPS_VERSION}.zip
+      unzip v${VIPS_VERSION}
+      cd libvips-${VIPS_VERSION}
+      test -f autogen.sh && ./autogen.sh || ./bootstrap.sh
+      CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 ./configure --disable-debug --disable-dependency-tracking --disable-introspection --disable-static --enable-gtk-doc-html=no --enable-gtk-doc=no --enable-pyvips8=no --without-orc --without-python $1
+      make
+    }
+    sudo make install
+    sudo ldconfig
+    cd ../..
 
 before_script:
 #  - go get -u github.com/golang/lint/golint


### PR DESCRIPTION
* The code checks never failed because the shell ignored any failure.
* Using caches saves some minutes of libvips compile time.
* Goveralls needs more setup … I removed it for now.
* Running the tests with `go test` does not work because there is no top-level package.
* Running the tests with `go test ./...` or `go test ./pkg/vips` does not work because of linker errors.
On my Mac the linking works but I get segmentation faults on test run.
