### PR TITLE
Added Size type, corresponding to VipsSize

### DIFF
--- a/pkg/vips/type.go
+++ b/pkg/vips/type.go
@@ -417,6 +417,18 @@ const (
 	BlendModeExclusion  BlendMode = C.VIPS_BLEND_MODE_EXCLUSION
 )
 
+// Size represents VIPS_SIZE type
+type Size int
+
+// Size enum
+const (
+	SizeBoth  Size = C.VIPS_SIZE_BOTH
+	SizeUp    Size = C.VIPS_SIZE_UP
+	SizeDown  Size = C.VIPS_SIZE_DOWN
+	SizeForce Size = C.VIPS_SIZE_FORCE
+	SizeLast  Size = C.VIPS_SIZE_LAST
+)
+
 var (
 	once                sync.Once
 	typeLoaders         = make(map[string]ImageType)


### PR DESCRIPTION
Added `Size` type to `type.go` corresponding to the [`VipsSize`][vipssize] enum type and defined the known values.

`VipsSize` is used in [`vips_thumbnail()`][vipsthumbnail]. Adding `Size` to govips make thumbnail operations with specific sizing constraints possible.

A very common case is to prohibit upsizing when creating thumbnails (generally not needed when embedding in web pages):
```golang
...
err := img.ThumbnailImage(
	400,
	vips.InputInt("size", int(vips.SizeDown)),
)
...
```

[vipssize]: https://libvips.github.io/libvips/API/current/libvips-resample.html#VipsSize
[vipsthumbnail]: https://libvips.github.io/libvips/API/current/libvips-resample.html#vips-thumbnail