### PR TITLE
Replace deprecated vips_warn with g_warning

### DIFF
--- a/pkg/vips/bridge.c
+++ b/pkg/vips/bridge.c
@@ -232,7 +232,7 @@ void gobject_set_property(VipsObject *object, const char *name, const GValue *va
 
   if( vips_object_get_argument( object, name,
     &pspec, &argument_class, &argument_instance ) ) {
-    vips_warn( NULL, "gobject warning: %s", vips_error_buffer() );
+    g_warning( "gobject warning: %s", vips_error_buffer() );
     vips_error_clear();
     return;
   }
@@ -246,7 +246,7 @@ void gobject_set_property(VipsObject *object, const char *name, const GValue *va
 
     if( (enum_value = vips_enum_from_nick( object_class->nickname,
       pspec_type, g_value_get_string( value ) )) < 0 ) {
-      vips_warn( NULL, "gobject warning: %s", vips_error_buffer() );
+      g_warning( "gobject warning: %s", vips_error_buffer() );
       vips_error_clear();
       return;
     }


### PR DESCRIPTION
See https://github.com/libvips/libvips/commit/2be0b97dce1eeb62a90c7dbb8947c50d05983e81

This commit should address the following warnings on OSX (I've seen something similar when building under Alpine Linux):
```
# github.com/davidbyttow/govips/pkg/vips
bridge.c:235:5: warning: implicit declaration of function 'vips_warn' is invalid in C99 [-Wimplicit-function-declaration]
bridge.c:249:7: warning: implicit declaration of function 'vips_warn' is invalid in C99 [-Wimplicit-function-declaration]
```