### PR TITLE
Increment VipsImage ref when creating new Image with `NewImageRef`

### DIFF
--- a/pkg/vips/image.go
+++ b/pkg/vips/image.go
@@ -82,6 +82,10 @@ func NewImageRef(vipsImage *C.VipsImage, format ImageType) *ImageRef {
 		image:  vipsImage,
 		format: format,
 	}
+
+	// Increment Ref as now that we have a new object pointing to the same VipsImage
+	C.g_object_ref(C.gpointer(stream.image))
+
 	runtime.SetFinalizer(stream, finalizeImage)
 	return stream
 }

--- a/pkg/vips/image.go
+++ b/pkg/vips/image.go
@@ -77,6 +77,25 @@ func NewImageFromBuffer(buf []byte, opts ...LoadOption) (*ImageRef, error) {
 	return ref, nil
 }
 
+// NewImageFromRef create a new ImageRef from an existing ImageRef
+func NewImageFromRef(ref *ImageRef) *ImageRef {
+	stream := &ImageRef{
+		image:  ref.image,
+		format: ref.format,
+		buf:    ref.buf,
+	}
+
+	// Increment Ref as now that we have a new object pointing to the same VipsImage
+	C.g_object_ref(C.gpointer(stream.image))
+
+	runtime.SetFinalizer(stream, finalizeImage)
+
+	return stream
+}
+
+// NewImageRef create a new ImageRef from an existing ImageRef
+// Deprecated: Use vips.NewImageFromRef instead. using this may leads to segmentation fault. to avoid it you must
+// keep reference to the buffer used to create the passed VipsImage
 func NewImageRef(vipsImage *C.VipsImage, format ImageType) *ImageRef {
 	stream := &ImageRef{
 		image:  vipsImage,

--- a/pkg/vips/transform.go
+++ b/pkg/vips/transform.go
@@ -474,6 +474,11 @@ func NewBlackboard(image *C.VipsImage, imageType ImageType, p *TransformParams) 
 	return bb
 }
 
+//Image return Blackboard current image
+func (bb *Blackboard) Image() *C.VipsImage {
+	return bb.image
+}
+
 // Width returns the width of the in-flight image
 func (bb *Blackboard) Width() int {
 	return int(bb.image.Xsize)

--- a/pkg/vips/transform.go
+++ b/pkg/vips/transform.go
@@ -555,7 +555,19 @@ func resize(bb *Blackboard) error {
 	}
 
 	if shrinkX != 1 || shrinkY != 1 {
-		bb.image, err = vipsResize(bb.image, 1.0/shrinkX, 1.0/shrinkY, kernel)
+
+		if cropMode && shrinkX > 1 && shrinkY > 1 && (bb.CropAnchor == AnchorFace || bb.CropAnchor == AnchorEntropy) {
+			var interesting int
+			if bb.CropAnchor == AnchorFace {
+				interesting = int(InterestingAttention)
+			} else if bb.CropAnchor == AnchorEntropy {
+				interesting = int(InterestingEntropy)
+			}
+			bb.image, err = ThumbnailImage(bb.image, bb.targetWidth, InputInt("height", bb.targetHeight), InputInt("crop", interesting))
+		} else {
+			bb.image, err = vipsResize(bb.image, 1.0/shrinkX, 1.0/shrinkY, kernel)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/pkg/vips/transform.go
+++ b/pkg/vips/transform.go
@@ -497,6 +497,19 @@ func (t *Transform) transform(image *C.VipsImage, imageType ImageType) (*C.VipsI
 	return bb.image, nil
 }
 
+// ProcessBlackboard Apply Blackboard transformations
+func ProcessBlackboard(bb *Blackboard) error {
+	if err := resize(bb); err != nil {
+		return err
+	}
+
+	if err := postProcess(bb); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func resize(bb *Blackboard) error {
 	var err error
 	kernel := bb.ReductionSampler

--- a/pkg/vips/type.go
+++ b/pkg/vips/type.go
@@ -74,6 +74,8 @@ const (
 	AnchorBottomLeft
 	AnchorBottomRight
 	AnchorLeft
+	AnchorFace
+	AnchorEntropy
 )
 
 // FlipDirection represents the direction to flip
@@ -294,6 +296,18 @@ const (
 	Angle45_225 Angle45 = C.VIPS_ANGLE45_D225
 	Angle45_270 Angle45 = C.VIPS_ANGLE45_D270
 	Angle45_315 Angle45 = C.VIPS_ANGLE45_D315
+)
+
+// Interesting represents VIPS_INTERESTING type
+type Interesting int
+
+// Interesting enum
+const (
+	InterestingNone      Interesting = C.VIPS_INTERESTING_NONE
+	InterestingCenter    Interesting = C.VIPS_INTERESTING_CENTRE
+	InterestingEntropy   Interesting = C.VIPS_INTERESTING_ENTROPY
+	InterestingAttention Interesting = C.VIPS_INTERESTING_ATTENTION
+	InterestingLast      Interesting = C.VIPS_INTERESTING_LAST
 )
 
 // Interpretation represents VIPS_INTERPRETATION type


### PR DESCRIPTION
This fixed `g_object_unref: assertion 'G_IS_OBJECT (object)' failed` errors that occurred when using `NewImageRef` to create multiple Image variants from the same ImageRef. As ref counter was not incremented when using `NewImageRef` but decremented when the finalizer is run on any of the newly created ImageRef(s), hence the ref assertion failure.

