### PR TITLE
Added support for OpenSlide formats.

### DIFF
--- a/pkg/vips/bridge.c
+++ b/pkg/vips/bridge.c
@@ -35,7 +35,7 @@ int init_image(void *buf, size_t len, int imageType, ImageLoadOptions *o, VipsIm
 
 int init_open_slide(const char *filename, VipsImage **out) {
     int code = 1;
-    code = vips_openslideload(filename, out, NULL);
+    code = vips_vipsload(filename, out, NULL);
     return code;
 }
 

--- a/pkg/vips/bridge.c
+++ b/pkg/vips/bridge.c
@@ -33,6 +33,16 @@ int init_image(void *buf, size_t len, int imageType, ImageLoadOptions *o, VipsIm
 	return code;
 }
 
+int init_open_slide(const char *filename, VipsImage **out) {
+    int code = 1;
+    code = vips_openslideload(filename, out, NULL);
+    return code;
+}
+
+VipsImage* init_from_file(const char *filename, ImageLoadOptions *o) {
+    return vips_image_new_from_file(filename, "access", o->access, NULL);
+}
+
 unsigned long has_profile_embed(VipsImage *in) {
 	return vips_image_get_typeof(in, VIPS_META_ICC_NAME);
 }

--- a/pkg/vips/bridge.h
+++ b/pkg/vips/bridge.h
@@ -17,7 +17,8 @@ enum types {
 	GIF,
 	PDF,
 	SVG,
-	MAGICK
+	MAGICK,
+    OPENSLIDE
 };
 typedef struct {
   const char *Text;
@@ -38,6 +39,8 @@ typedef struct {
 } ImageLoadOptions;
 
 int init_image(void *buf, size_t len, int imageType, ImageLoadOptions *o, VipsImage **out);
+int init_open_slide(const char *filename, VipsImage **out);
+VipsImage* init_from_file(const char *filename, ImageLoadOptions *o);
 int find_image_type_loader(int t);
 int find_image_type_saver(int t);
 

--- a/pkg/vips/image.go
+++ b/pkg/vips/image.go
@@ -77,6 +77,33 @@ func NewImageFromBuffer(buf []byte, opts ...LoadOption) (*ImageRef, error) {
 	return ref, nil
 }
 
+// NewImageFromOpenSlide loads an OpenSlide file and creates a new Image
+func NewImageFromOpenSlide(file string) (*ImageRef, error) {
+	startupIfNeeded()
+
+	image, err := vipsLoadFromOpenSlide(file)
+	if err != nil {
+		return nil, err
+	}
+
+	ref := NewImageRef(image, ImageTypeOpenSlide)
+	return ref, nil
+}
+
+// NewImageFromFileExtra loads an image with any other format (if supported) from file
+// It detects the type and seletc a loader automatically
+func NewImageFromFileExtra(file string, opts ...LoadOption) (*ImageRef, error) {
+	startupIfNeeded()
+
+	image, err := vipsLoadFromFile(file, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	ref := NewImageRef(image, ImageTypeUnknown)
+	return ref, nil
+}
+
 func NewImageRef(vipsImage *C.VipsImage, format ImageType) *ImageRef {
 	stream := &ImageRef{
 		image:  vipsImage,

--- a/pkg/vips/type.go
+++ b/pkg/vips/type.go
@@ -92,15 +92,16 @@ type ImageType int
 
 // ImageType enum
 const (
-	ImageTypeUnknown ImageType = C.UNKNOWN
-	ImageTypeGIF     ImageType = C.GIF
-	ImageTypeJPEG    ImageType = C.JPEG
-	ImageTypeMagick  ImageType = C.MAGICK
-	ImageTypePDF     ImageType = C.PDF
-	ImageTypePNG     ImageType = C.PNG
-	ImageTypeSVG     ImageType = C.SVG
-	ImageTypeTIFF    ImageType = C.TIFF
-	ImageTypeWEBP    ImageType = C.WEBP
+	ImageTypeUnknown   ImageType = C.UNKNOWN
+	ImageTypeGIF       ImageType = C.GIF
+	ImageTypeJPEG      ImageType = C.JPEG
+	ImageTypeMagick    ImageType = C.MAGICK
+	ImageTypePDF       ImageType = C.PDF
+	ImageTypePNG       ImageType = C.PNG
+	ImageTypeSVG       ImageType = C.SVG
+	ImageTypeTIFF      ImageType = C.TIFF
+	ImageTypeWEBP      ImageType = C.WEBP
+	ImageTypeOpenSlide ImageType = C.OPENSLIDE
 )
 
 var imageTypeExtensionMap = map[ImageType]string{
@@ -372,14 +373,15 @@ const (
 )
 
 var ImageTypes = map[ImageType]string{
-	ImageTypeGIF:    "gif",
-	ImageTypeJPEG:   "jpeg",
-	ImageTypeMagick: "magick",
-	ImageTypePDF:    "pdf",
-	ImageTypePNG:    "png",
-	ImageTypeSVG:    "svg",
-	ImageTypeTIFF:   "tiff",
-	ImageTypeWEBP:   "webp",
+	ImageTypeGIF:       "gif",
+	ImageTypeJPEG:      "jpeg",
+	ImageTypeMagick:    "magick",
+	ImageTypePDF:       "pdf",
+	ImageTypePNG:       "png",
+	ImageTypeSVG:       "svg",
+	ImageTypeTIFF:      "tiff",
+	ImageTypeWEBP:      "webp",
+	ImageTypeOpenSlide: "openslide",
 }
 
 type Composite struct {


### PR DESCRIPTION
libvips support OpenSlide formats by default. The current binding initiates vips images only from buffer.  OpenSlide images cannot be loaded this way. I added several new APIs specifically to load OpenSlide images and images of any other formats that libvips possibly supports.