### PR TITLE
Add func NewImageFromNativeImage

### DIFF
--- a/pkg/vips/image_test.go
+++ b/pkg/vips/image_test.go
@@ -2,10 +2,14 @@ package vips_test
 
 import (
 	"bytes"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
 	"io/ioutil"
 	"testing"
 
-	"github.com/davidbyttow/govips/pkg/vips"
+	"../vips"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -142,6 +146,70 @@ func TestNewImageFromBuffer_AccessMode(t *testing.T) {
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "out of order")
 		}
+	}
+}
+
+func TestNewImageFromNativeImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		img       draw.Image
+		fillcolor color.Color
+	}{
+		{
+			"image.Gray",
+			image.NewGray(image.Rect(0, 0, 64, 64)),
+			color.RGBA{0x7F, 0x7F, 0x7F, 0xFF},
+		},
+		{
+			"image.RGBA",
+			image.NewRGBA(image.Rect(0, 0, 64, 64)),
+			color.RGBA{0x0, 0x0, 0xFF, 0xFF},
+		},
+		{
+			"image.Gray16",
+			image.NewGray16(image.Rect(0, 0, 64, 64)),
+			color.RGBA{0x7F, 0x7F, 0x7F, 0xFF},
+		},
+		{
+			"image.RGBA64",
+			image.NewRGBA64(image.Rect(0, 0, 64, 64)),
+			color.RGBA{0x0, 0x0, 0xFF, 0xFF},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Fill the image with a color to be able to test it
+			fill := image.NewUniform(tt.fillcolor)
+			draw.Draw(tt.img, tt.img.Bounds(), fill, image.ZP, draw.Src)
+			vimg, err := vips.NewImageFromNativeImage(tt.img)
+			if assert.NoError(t, err) {
+				assert.NotNil(t, vimg)
+			}
+			// Encode the image to be able to examine it pixel by pixel
+			buf, _, err := vips.NewTransform().
+				Image(vimg).
+				Format(vips.ImageTypePNG).
+				OutputBytes().
+				Apply()
+			assert.NoError(t, err)
+			// Decode the result
+			decoded, err := png.Decode(bytes.NewBuffer(buf))
+			if assert.NoError(t, err) {
+				// Check it pixel by pixel
+			PixelCheck:
+				for x := decoded.Bounds().Min.X; x < decoded.Bounds().Max.X; x++ {
+					for y := decoded.Bounds().Min.Y; y < decoded.Bounds().Max.Y; y++ {
+						ar, ag, ab, aa := tt.fillcolor.RGBA()
+						br, bg, bb, ba := decoded.At(x, y).RGBA()
+						if ar != br || ag != bg || ab != bb || aa != ba {
+							// Only assert if it would fail, and then break or the test hangs
+							assert.Equal(t, tt.fillcolor, decoded.At(x, y))
+							break PixelCheck
+						}
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/vips/leak_test.go
+++ b/pkg/vips/leak_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/davidbyttow/govips/pkg/vips"
+	"../vips"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/vips/options_test.go
+++ b/pkg/vips/options_test.go
@@ -3,7 +3,7 @@ package vips_test
 import (
 	"testing"
 
-	"github.com/davidbyttow/govips/pkg/vips"
+	"../vips"
 )
 
 func TestOptionPrimitives(t *testing.T) {

--- a/pkg/vips/regression_test.go
+++ b/pkg/vips/regression_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/davidbyttow/govips/pkg/vips"
+	"../vips"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/vips/transform_test.go
+++ b/pkg/vips/transform_test.go
@@ -3,7 +3,7 @@ package vips_test
 import (
 	"testing"
 
-	"github.com/davidbyttow/govips/pkg/vips"
+	"../vips"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/vips/type_test.go
+++ b/pkg/vips/type_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/davidbyttow/govips/pkg/vips"
+	"../vips"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Uses vips_image_new_from_memory to load an image already in memory

I imagine the most common use case for govips is to convert/transform etc some image file and then save it to a different image file, but it would be nice to be able to operate on an image that's already in memory. Thus we can leverage govips to encode an image.Image, which we might have rendered, generated or loaded in some other way.

This PR is somewhat related to #2 - solving for the case where the image in memory is an image.Gray(16) or image.RGBA(64), or could be converted to it.