### PR TITLE
Open PDFs with options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
   - 1.9
 
 env:
-  - VIPS_VERSION=8.8.1
+  - VIPS_VERSION=8.7.4
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
   - 1.9
 
 env:
-  - VIPS_VERSION=8.6.2
+  - VIPS_VERSION=8.8.1
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
     test -d libvips-${VIPS_VERSION} && {
       cd libvips-${VIPS_VERSION}
     } || {
-      wget https://github.com/jcupitt/libvips/archive/v${VIPS_VERSION}.zip
+      wget https://github.com/libvips/libvips/archive/v${VIPS_VERSION}.zip
       unzip v${VIPS_VERSION}
       cd libvips-${VIPS_VERSION}
       test -f autogen.sh && ./autogen.sh || ./bootstrap.sh

--- a/pkg/vips/bridge.c
+++ b/pkg/vips/bridge.c
@@ -54,11 +54,6 @@ int get_pages(VipsImage *in) {
 	if (vips_image_get (in, VIPS_META_N_PAGES, &value))
 	  return -1;
 
-	// if (G_VALUE_TYPE (&value) != G_TYPE_DOUBLE) {
-	//   g_value_unset (&value);
-	//   return -1;
-	// }
-
 	d = g_value_get_int (&value);
 	g_value_unset (&value);
   return d;

--- a/pkg/vips/bridge.c
+++ b/pkg/vips/bridge.c
@@ -21,7 +21,13 @@ int init_image(void *buf, size_t len, int imageType, ImageLoadOptions *o, VipsIm
 	} else if (imageType == GIF) {
 		code = vips_gifload_buffer(buf, len, out, "access", o->access, NULL);
 	} else if (imageType == PDF) {
-		code = vips_pdfload_buffer(buf, len, out, "access", o->access, NULL);
+		code = vips_pdfload_buffer(buf, len, out,
+ 			"access", o->access,
+ 			"page", o->Page,
+ 			"n", o->N,
+ 			"dpi", o->DPI,
+ 			NULL
+		);
 	} else if (imageType == SVG) {
 		code = vips_svgload_buffer(buf, len, out, "access", o->access, NULL);
 #endif
@@ -35,6 +41,27 @@ int init_image(void *buf, size_t len, int imageType, ImageLoadOptions *o, VipsIm
 
 unsigned long has_profile_embed(VipsImage *in) {
 	return vips_image_get_typeof(in, VIPS_META_ICC_NAME);
+}
+
+unsigned long has_pages_embed(VipsImage *in) {
+	return vips_image_get_typeof(in, VIPS_META_N_PAGES);
+}
+
+int get_pages(VipsImage *in) {
+  	GValue value = { 0 };
+  	int d;
+
+	if (vips_image_get (in, VIPS_META_N_PAGES, &value))
+	  return -1;
+
+	// if (G_VALUE_TYPE (&value) != G_TYPE_DOUBLE) {
+	//   g_value_unset (&value);
+	//   return -1;
+	// }
+
+	d = g_value_get_int (&value);
+	g_value_unset (&value);
+  return d;
 }
 
 int remove_icc_profile(VipsImage *in) {

--- a/pkg/vips/bridge.go
+++ b/pkg/vips/bridge.go
@@ -89,6 +89,14 @@ func vipsHasProfile(input *C.VipsImage) bool {
 	return int(C.has_profile_embed(input)) > 0
 }
 
+func vipsHasPages(input *C.VipsImage) bool {
+	return int(C.has_pages_embed(input)) > 0
+}
+
+func vipsGetPages(input *C.VipsImage) int {
+	return int(C.get_pages(input))
+}
+
 func vipsPrepareForExport(input *C.VipsImage, params *ExportParams) (*C.VipsImage, error) {
 	if params.StripProfile && vipsHasProfile(input) {
 		C.remove_icc_profile(input)

--- a/pkg/vips/bridge.h
+++ b/pkg/vips/bridge.h
@@ -35,6 +35,9 @@ typedef struct {
 
 typedef struct {
 	int access;
+	int Page;
+	int N;
+	double DPI;
 } ImageLoadOptions;
 
 int init_image(void *buf, size_t len, int imageType, ImageLoadOptions *o, VipsImage **out);
@@ -51,6 +54,8 @@ int copy_image(VipsImage *in, VipsImage **out);
 int to_colorspace(VipsImage *in, VipsImage **out, VipsInterpretation space);
 int is_colorspace_supported(VipsImage *in);
 unsigned long has_profile_embed(VipsImage *in);
+unsigned long has_pages_embed(VipsImage *in);
+int get_pages(VipsImage *in);
 int remove_icc_profile(VipsImage *in);
 int extract_band(VipsImage *in, VipsImage **out, int band, int num);
 int linear1(VipsImage *in, VipsImage **out, double a, double b);

--- a/pkg/vips/image.go
+++ b/pkg/vips/image.go
@@ -26,6 +26,16 @@ type ImageRef struct {
 
 type LoadOption func(o *vipsLoadOptions)
 
+// Image with PDF LoadOptions
+func WithPDFOptions(Page int, N int, DPI int) LoadOption {
+	return func(o *vipsLoadOptions) {
+		o.cOpts.access = C.VIPS_ACCESS_RANDOM
+		o.cOpts.Page = C.int(Page)
+		o.cOpts.N = C.int(N)
+		o.cOpts.DPI = C.double(DPI)
+	}
+}
+
 func WithAccessMode(a Access) LoadOption {
 	return func(o *vipsLoadOptions) {
 		switch a {
@@ -185,6 +195,15 @@ func (ref *ImageRef) Export(params ExportParams) ([]byte, ImageType, error) {
 // HasProfile returns if the image has an ICC profile embedded.
 func (ref *ImageRef) HasProfile() bool {
 	return vipsHasProfile(ref.image)
+}
+
+// GetPages returns pages per VIPS_META_N_PAGES in the profile
+// Only for Type PDF
+func (ref *ImageRef) GetPages() int {
+	if !vipsHasPages(ref.image) {
+		return -1
+	}
+	return vipsGetPages(ref.image)
 }
 
 // ToBytes writes the image to memory in VIPs format and returns the raw bytes, useful for storage.


### PR DESCRIPTION
_NOTE: Requires libvips 8.7.0+_

 For my project, I needed the ability to open PDFs from govips. 

Added the following options to [vips-pdfload-buffer()](https://jcupitt.github.io/libvips/API/current/VipsForeignSave.html#vips-pdfload-buffer):

**page** : _gint, load this page, numbered from zero_
**n** : _gint, load this many pages_
**dpi** : _gdouble, render at this DPI_

```
// Get total pages of document
tmp, err := vips.NewImageFromBuffer(inputFile, vips.WithPDFOptions(0,1,75))
if err != nil {
   panic(err)
}
defer tmp.Close()
pages := tmp.GetPages()

// Iterate on each page and pull it into an *ImageRef
for i := 0; i < pages; i++ {
  img, err := vips.NewImageFromBuffer(inputFile, vips.WithPDFOptions(i,1,400))
  if err != nil {
    panic(err)
  }
  defer img.Close()
}
```