### PR TITLE
Fix copy-paste typo

### DIFF
--- a/pkg/vips/transform.go
+++ b/pkg/vips/transform.go
@@ -212,7 +212,7 @@ func (t *Transform) Crop(anchor Anchor) *Transform {
 
 // Stretch an image without maintaining aspect ratio
 func (t *Transform) Stretch() *Transform {
-	t.tx.ResizeStrategy = ResizeStrategyCrop
+	t.tx.ResizeStrategy = ResizeStrategyStretch
 	return t
 }
 


### PR DESCRIPTION
Current `Transform.Stretch()` implementation is looks like broken :)