### PR TITLE
add comsposite multi api. Closes #129 .

### DIFF
--- a/vips/composite.go
+++ b/vips/composite.go
@@ -1,0 +1,28 @@
+package vips
+
+// #cgo pkg-config: vips
+// #include <vips/vips.h>
+import "C"
+
+// ImageComposite image to composite param
+type ImageComposite struct {
+	Image     *ImageRef
+	BlendMode BlendMode
+	X, Y      int
+}
+
+func toVipsCompositeStructs(r *ImageRef, datas []*ImageComposite) ([]*C.VipsImage, []C.int, []C.int, []C.int) {
+	ins := []*C.VipsImage{r.image}
+	modes := []C.int{}
+	xs := []C.int{}
+	ys := []C.int{}
+
+	for _, image := range datas {
+		ins = append(ins, image.Image.image)
+		modes = append(modes, C.int(image.BlendMode))
+		xs = append(xs, C.int(image.X))
+		ys = append(ys, C.int(image.Y))
+	}
+
+	return ins, modes, xs, ys
+}

--- a/vips/conversion.c
+++ b/vips/conversion.c
@@ -96,6 +96,17 @@ double max_alpha(VipsImage *in) {
     }
 }
 
+int composite_image(VipsImage **in, VipsImage **out, int n, int *mode, int *x, int *y) {
+	VipsArrayInt *xs = vips_array_int_new(x, n-1);
+	VipsArrayInt *ys = vips_array_int_new(y, n-1);
+
+	int code = vips_composite(in, out, n, mode, "x", xs, "y", ys, NULL);
+
+	vips_area_unref(VIPS_AREA(xs));
+	vips_area_unref(VIPS_AREA(ys));
+	return code;
+}
+
 int composite2_image(VipsImage *base, VipsImage *overlay, VipsImage **out, int mode, gint x, gint y) {
 	return vips_composite2(base, overlay, out, mode, "x", x, "y", y, NULL);
 }

--- a/vips/conversion.go
+++ b/vips/conversion.go
@@ -270,6 +270,18 @@ func vipsCast(in *C.VipsImage, bandFormat BandFormat) (*C.VipsImage, error) {
 	return out, nil
 }
 
+// https://libvips.github.io/libvips/API/current/libvips-conversion.html#vips-composite
+func vipsComposite(ins []*C.VipsImage, modes []C.int, xs, ys []C.int) (*C.VipsImage, error) {
+	incOpCounter("composite_multi")
+	var out *C.VipsImage
+
+	if err := C.composite_image(&ins[0], &out, C.int(len(ins)), &modes[0], &xs[0], &ys[0]); err != 0 {
+		return nil, handleImageError(out)
+	}
+
+	return out, nil
+}
+
 // https://libvips.github.io/libvips/API/current/libvips-conversion.html#vips-composite2
 func vipsComposite2(base *C.VipsImage, overlay *C.VipsImage, mode BlendMode, x, y int) (*C.VipsImage, error) {
 	incOpCounter("composite")

--- a/vips/conversion.h
+++ b/vips/conversion.h
@@ -26,6 +26,7 @@ int unpremultiply_alpha(VipsImage *in, VipsImage **out);
 int cast(VipsImage *in, VipsImage **out, int bandFormat);
 double max_alpha(VipsImage *in);
 
+int composite_image(VipsImage **in, VipsImage **out, int n, int *mode, int *x, int *y);
 int composite2_image(VipsImage *base, VipsImage *overlay, VipsImage **out, int mode, gint x, gint y);
 
 int is_16bit(VipsInterpretation interpretation);

--- a/vips/image.go
+++ b/vips/image.go
@@ -342,6 +342,16 @@ func (r *ImageRef) Export(params *ExportParams) ([]byte, *ImageMetadata, error) 
 	return buf, metadata, nil
 }
 
+// CompositeMulti composites the given overlay image on top of the associated image with provided blending mode.
+func (r *ImageRef) CompositeMulti(ins []*ImageComposite) error {
+	out, err := vipsComposite(toVipsCompositeStructs(r, ins))
+	if err != nil {
+		return err
+	}
+	r.setImage(out)
+	return nil
+}
+
 // Composite composites the given overlay image on top of the associated image with provided blending mode.
 func (r *ImageRef) Composite(overlay *ImageRef, mode BlendMode, x, y int) error {
 	out, err := vipsComposite2(r.image, overlay.image, mode, x, y)

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -437,6 +437,41 @@ func TestImageRef_Label(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestImageRef_Composite(t *testing.T) {
+	Startup(nil)
+
+	image, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+
+	imageOverlay, err := NewImageFromFile(resources + "png-8bit+alpha.png")
+	require.NoError(t, err)
+
+	err = image.Composite(imageOverlay, BlendModeXOR, 10, 20)
+	require.NoError(t, err)
+}
+
+func TestImageRef_CompositeMulti(t *testing.T) {
+	Startup(nil)
+
+	image, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+
+	images := []*ImageComposite{}
+	for i, uri := range []string{"png-8bit+alpha.png", "png-24bit+alpha.png"} {
+		image, err := NewImageFromFile(resources + uri)
+		require.NoError(t, err)
+
+		//add offset test
+		images = append(images, &ImageComposite{image, BlendModeOver, (i + 1) * 20, (i + 2) * 20})
+	}
+
+	err = image.CompositeMulti(images)
+	require.NoError(t, err)
+
+	_, _, err = image.Export(nil)
+	require.NoError(t, err)
+}
+
 // TODO Add unit tests for:
 // Copy
 // Close
@@ -447,7 +482,6 @@ func TestImageRef_Label(t *testing.T) {
 // OffsetY
 // Coding
 // IsColosSpaceSupported
-// Composite
 // ExtractBand
 // BandJoin
 // GetRotationAngleFromEXIF


### PR DESCRIPTION
1. add new api `CompositeMulti` which can composite multiple images at one command.
1. maintain backwards compatibility `Composite` call inner `vips_composite2`.
2. add composite test cases.

