### PR TITLE
Avoid allocating a new go byte slice buffer and reuse the C buffer on export

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"image/png"
 	"math"
+	"reflect"
 	"runtime"
 	"unsafe"
 
@@ -302,8 +303,12 @@ func vipsSaveJPEGToBuffer(in *C.VipsImage, quality int, stripMetadata, interlace
 }
 
 func toBuff(ptr unsafe.Pointer, cLen C.size_t) []byte {
-	buf := C.GoBytes(ptr, C.int(cLen))
-	gFreePointer(ptr)
-
-	return buf
+	// Create a go slice from the C memory without copying the data
+	// https://stackoverflow.com/questions/51187973/how-to-create-an-array-or-a-slice-from-an-array-unsafe-pointer-in-golang
+	sh := &reflect.SliceHeader{
+		Data: uintptr(ptr),
+		Len:  int(cLen),
+		Cap:  int(cLen),
+	}
+	return *(*[]byte)(unsafe.Pointer(sh))
 }

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -472,6 +472,24 @@ func TestImageRef_CompositeMulti(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func BenchmarkCreateNewImage(b *testing.B) {
+	Startup(nil)
+
+	fileBuf, err := ioutil.ReadFile(resources + "heic-24bit.heic")
+	require.NoError(b, err)
+
+	b.SetParallelism(100)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		img, err := NewImageFromBuffer(fileBuf)
+		require.NoError(b, err)
+
+		_, _, err = img.Export(NewDefaultJPEGExportParams())
+		require.NoError(b, err)
+	}
+	b.ReportAllocs()
+}
+
 // TODO Add unit tests for:
 // Copy
 // Close

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -472,18 +472,18 @@ func TestImageRef_CompositeMulti(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func BenchmarkCreateNewImage(b *testing.B) {
+func BenchmarkExportImage(b *testing.B) {
 	Startup(nil)
 
 	fileBuf, err := ioutil.ReadFile(resources + "heic-24bit.heic")
 	require.NoError(b, err)
 
+	img, err := NewImageFromBuffer(fileBuf)
+	require.NoError(b, err)
+
 	b.SetParallelism(100)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		img, err := NewImageFromBuffer(fileBuf)
-		require.NoError(b, err)
-
 		_, _, err = img.Export(NewDefaultJPEGExportParams())
 		require.NoError(b, err)
 	}


### PR DESCRIPTION
This saves some quite large allocations when working with larger images.

I added an extra benchmark that shows this:

## Before:
```
BenchmarkExportImage-8   	      32	  35683545 ns/op	  377113 B/op	       6 allocs/op
```

## After:
```
BenchmarkExportImage-8   	      31	  35990512 ns/op	     280 B/op	       5 allocs/op
```
