### PR TITLE
Fix panic on shutdown

### DIFF
--- a/vips/govips.c
+++ b/vips/govips.c
@@ -7,6 +7,12 @@ static void govips_logging_handler(
   govipsLoggingHandler((char *)log_domain, (int)log_level, (char *)message);
 }
 
+static void null_logging_handler(
+    const gchar *log_domain, GLogLevelFlags log_level,
+    const gchar *message, gpointer user_data)
+{
+}
+
 void vips_set_logging_handler(void)
 {
   g_log_set_default_handler(govips_logging_handler, NULL);
@@ -14,5 +20,5 @@ void vips_set_logging_handler(void)
 
 void vips_unset_logging_handler(void)
 {
-  g_log_set_default_handler(NULL, NULL);
+  g_log_set_default_handler(null_logging_handler, NULL);
 }

--- a/vips/govips.c
+++ b/vips/govips.c
@@ -1,13 +1,18 @@
 #include "govips.h"
 
 static void govips_logging_handler(
-	const gchar *log_domain, GLogLevelFlags log_level,
-	const gchar *message, gpointer user_data)
+    const gchar *log_domain, GLogLevelFlags log_level,
+    const gchar *message, gpointer user_data)
 {
-	govipsLoggingHandler((char *)log_domain, (int)log_level, (char *)message);
+  govipsLoggingHandler((char *)log_domain, (int)log_level, (char *)message);
 }
 
 void vips_set_logging_handler(void)
 {
-	g_log_set_default_handler(govips_logging_handler, NULL);
+  g_log_set_default_handler(govips_logging_handler, NULL);
+}
+
+void vips_unset_logging_handler(void)
+{
+  g_log_set_default_handler(NULL, NULL);
 }

--- a/vips/govips.go
+++ b/vips/govips.go
@@ -86,6 +86,7 @@ func Startup(config *Config) {
 	// Initialize govips logging handler and verbosity filter to historical default
 	if !currentLoggingOverridden {
 		LoggingSettings(nil, LogLevelInfo)
+		currentLoggingOverridden = false
 	}
 
 	// Override default glib logging handler to intercept logging messages

--- a/vips/govips.go
+++ b/vips/govips.go
@@ -35,6 +35,7 @@ const (
 
 var (
 	running             = false
+	hasShutdown         = false
 	initLock            sync.Mutex
 	statCollectorDone   chan struct{}
 	once                sync.Once
@@ -56,9 +57,14 @@ type Config struct {
 // Startup sets up the libvips support and ensures the versions are correct. Pass in nil for
 // default configuration.
 func Startup(config *Config) {
+	if hasShutdown {
+		panic("govips cannot be stopped and restarted")
+	}
+
 	initLock.Lock()
-	runtime.LockOSThread()
 	defer initLock.Unlock()
+
+	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	if running {
@@ -78,9 +84,8 @@ func Startup(config *Config) {
 	defer freeCString(cName)
 
 	// Initialize govips logging handler and verbosity filter to historical default
-	if !currentLoggingOverriden {
+	if !currentLoggingOverridden {
 		LoggingSettings(nil, LogLevelInfo)
-		currentLoggingOverriden = false
 	}
 
 	// Override default glib logging handler to intercept logging messages
@@ -151,13 +156,16 @@ func Startup(config *Config) {
 
 // Shutdown libvips
 func Shutdown() {
+	hasShutdown = true
+
 	if statCollectorDone != nil {
 		statCollectorDone <- struct{}{}
 	}
 
 	initLock.Lock()
-	runtime.LockOSThread()
 	defer initLock.Unlock()
+
+	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	if !running {
@@ -166,10 +174,12 @@ func Shutdown() {
 	}
 
 	C.vips_shutdown()
+	C.vips_unset_logging_handler()
 	running = false
 }
 
-// ShutdownThread clears the cache for for the given thread.
+// ShutdownThread clears the cache for for the given thread. This needs to be
+// called when a thread using vips exits.
 func ShutdownThread() {
 	C.vips_thread_shutdown()
 }

--- a/vips/govips.h
+++ b/vips/govips.h
@@ -14,3 +14,4 @@ static void govips_logging_handler(
     const gchar *message, gpointer user_data);
 
 void vips_set_logging_handler(void);
+void vips_unset_logging_handler(void);

--- a/vips/govips.h
+++ b/vips/govips.h
@@ -13,5 +13,9 @@ static void govips_logging_handler(
     const gchar *log_domain, GLogLevelFlags log_level,
     const gchar *message, gpointer user_data);
 
+static void null_logging_handler(
+    const gchar *log_domain, GLogLevelFlags log_level,
+    const gchar *message, gpointer user_data);
+
 void vips_set_logging_handler(void);
 void vips_unset_logging_handler(void);

--- a/vips/logging.go
+++ b/vips/logging.go
@@ -27,7 +27,7 @@ const (
 var (
 	currentLoggingHandlerFunction LoggingHandlerFunction
 	currentLoggingVerbosity       LogLevel
-	currentLoggingOverriden       bool
+	currentLoggingOverridden      bool
 )
 
 // govipsLoggingHandler is the private bridge function exported to the C library
@@ -63,7 +63,7 @@ func LoggingSettings(handler LoggingHandlerFunction, verbosity LogLevel) {
 	// TODO turn on debugging in libvips and redirect to handler when setting verbosity to debug
 	// This way debugging information would go to the same channel as all other logging
 
-	currentLoggingOverriden = true
+	currentLoggingOverridden = true
 }
 
 func defaultLoggingHandlerFunction(messageDomain string, messageLevel LogLevel, message string) {


### PR DESCRIPTION
Upon termination, if libvips continues work in another thread (such as for reporting leaks) and logs, then a panic will occur if the log handler is a callback into Go. This is not an ideal fix because all processes/threads should terminate appropriately, but it's a stopgap to prevent the failure.

There may be a better way to handle this (via a signal callback or something else) to catch it just as Go is exiting and unset the handler.

Users are suggested to call Shutdown() upon exit to avoid this error.