### PR TITLE
add ushort parameter to Identity

### DIFF
--- a/vips/create.c
+++ b/vips/create.c
@@ -12,6 +12,10 @@ int black(VipsImage **out, int width, int height) {
 }
 
 // https://libvips.github.io/libvips/API/current/libvips-create.html#vips-identity
-int identity(VipsImage **out, bool ushort) {
-	return vips_identity(out, ushort, NULL);
+int identity(VipsImage **out, int ushort) {
+	if (ushort > 0){
+		return vips_identity(out, "ushort", TRUE, NULL);
+	} else {
+		return vips_identity(out, NULL);
+	}
 }

--- a/vips/create.c
+++ b/vips/create.c
@@ -12,6 +12,6 @@ int black(VipsImage **out, int width, int height) {
 }
 
 // https://libvips.github.io/libvips/API/current/libvips-create.html#vips-identity
-int identity(VipsImage **out) {
-	return vips_identity(out, NULL);
+int identity(VipsImage **out, bool ushort) {
+	return vips_identity(out, ushort, NULL);
 }

--- a/vips/create.go
+++ b/vips/create.go
@@ -27,10 +27,10 @@ func vipsBlack(width int, height int) (*C.VipsImage, error) {
 }
 
 // https://libvips.github.io/libvips/API/current/libvips-create.html#vips-identity
-func vipsIdentity() (*C.VipsImage, error) {
+func vipsIdentity(ushort bool) (*C.VipsImage, error) {
 	var out *C.VipsImage
 
-	if err := C.identity(&out); err != 0 {
+	if err := C.identity(&out, ushort); err != 0 {
 		return nil, handleImageError(out)
 	}
 

--- a/vips/create.go
+++ b/vips/create.go
@@ -29,8 +29,8 @@ func vipsBlack(width int, height int) (*C.VipsImage, error) {
 // https://libvips.github.io/libvips/API/current/libvips-create.html#vips-identity
 func vipsIdentity(ushort bool) (*C.VipsImage, error) {
 	var out *C.VipsImage
-
-	if err := C.identity(&out, ushort); err != 0 {
+	ushortInt := C.int(boolToInt(ushort))
+	if err := C.identity(&out, ushortInt); err != 0 {
 		return nil, handleImageError(out)
 	}
 

--- a/vips/create.h
+++ b/vips/create.h
@@ -6,4 +6,4 @@
 
 int xyz(VipsImage **out, int width, int height);
 int black(VipsImage **out, int width, int height);
-int identity(VipsImage **out);
+int identity(VipsImage **out, int ushort);

--- a/vips/image.go
+++ b/vips/image.go
@@ -250,8 +250,8 @@ func XYZ(width, height int) (*ImageRef, error) {
 
 // Identity creates an identity lookup table, which will leave an image unchanged when applied with Maplut.
 // Each entry in the table has a value equal to its position.
-func Identity() (*ImageRef, error) {
-	img, err := vipsIdentity()
+func Identity(ushort bool) (*ImageRef, error) {
+	img, err := vipsIdentity(ushort)
 	return &ImageRef{image: img}, err
 }
 

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -690,7 +690,9 @@ func TestXYZ(t *testing.T) {
 func TestIdentity(t *testing.T) {
 	Startup(nil)
 
-	_, err := Identity()
+	_, err := Identity(false)
+	require.NoError(t, err)
+	_, err = Identity(true)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
this PR adds a a ushort parameter to the Identity call. When set to true the resulting LUT will be 16 bit wide

https://libvips.github.io/libvips/API/current/libvips-create.html#vips-identity