### PR TITLE
Improve BMP performance by using no PNG compression during conversion

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -254,7 +254,10 @@ func bmpToPNG(src []byte) ([]byte, error) {
 	}
 
 	var w bytes.Buffer
-	err = png.Encode(&w, i)
+	pngEnc := png.Encoder{
+		CompressionLevel: png.NoCompression,
+	}
+	err = pngEnc.Encode(&w, i)
 	if err != nil {
 		return nil, err
 	}

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -586,6 +586,21 @@ func BenchmarkExportImage(b *testing.B) {
 	b.ReportAllocs()
 }
 
+func BenchmarkOpenBMPImage(b *testing.B) {
+	Startup(nil)
+
+	fileBuf, err := ioutil.ReadFile(resources + "large.bmp")
+	require.NoError(b, err)
+
+	b.SetParallelism(100)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, err := NewImageFromBuffer(fileBuf)
+		require.NoError(b, err)
+	}
+	b.ReportAllocs()
+}
+
 func TestMemstats(t *testing.T) {
 	var stats MemoryStats
 	ReadVipsMemStats(&stats)


### PR DESCRIPTION
I noticed that opening (large) BMP images was quite slow, especially since the image format is so simple. Digging a bit deeper I noticed that govips actually handles BMP images in go and converts them to PNG prior to feeding them to vips.

This makes sense, however, the PNG's it creates are compressed, which means they can take quite a long time to generate. I therefore propose to generate the PNG's without any compression, thus speeding up the load times of large BMPs by a significant margin.

### Before

```
/tmp/___BenchmarkOpenBMPImage_in_github_com_davidbyttow_govips_v2_vips -test.v -test.paniconexit0 -test.bench ^\QBenchmarkOpenBMPImage\E$ -test.run ^$
goos: linux
goarch: amd64
pkg: github.com/davidbyttow/govips/v2/vips
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
BenchmarkOpenBMPImage
BenchmarkOpenBMPImage-8   	      31	  37913931 ns/op	 9201873 B/op	      48 allocs/op
PASS
```

### After

```
tmp/___BenchmarkOpenBMPImage_in_github_com_davidbyttow_govips_v2_vips -test.v -test.paniconexit0 -test.bench ^\QBenchmarkOpenBMPImage\E$ -test.run ^$
goos: linux
goarch: amd64
pkg: github.com/davidbyttow/govips/v2/vips
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
BenchmarkOpenBMPImage
BenchmarkOpenBMPImage-8   	      78	  14486767 ns/op	25654101 B/op	     241 allocs/op
PASS
```

### Even larger BMP

My testcase was a BMP file of > 36MiB coming in at 4272x2848 pixels. The results for that one are as follows:

Before:
```
BenchmarkOpenBMPImage-8   	       1	7887446859 ns/op	82931160 B/op	     443 allocs/op
```

After:
```
BenchmarkOpenBMPImage-8   	      12	  86786504 ns/op	183687355 B/op	    1170 allocs/op
```