### PR TITLE
Fix InterpretationGB16 definition

### DIFF
--- a/vips/color.go
+++ b/vips/color.go
@@ -38,7 +38,7 @@ const (
 	InterpretationSRGB      Interpretation = C.VIPS_INTERPRETATION_sRGB
 	InterpretationYXY       Interpretation = C.VIPS_INTERPRETATION_YXY
 	InterpretationFourier   Interpretation = C.VIPS_INTERPRETATION_FOURIER
-	InterpretationGB16      Interpretation = C.VIPS_INTERPRETATION_RGB16
+	InterpretationGB16      Interpretation = C.VIPS_INTERPRETATION_GB16
 	InterpretationGrey16    Interpretation = C.VIPS_INTERPRETATION_GREY16
 	InterpretationMatrix    Interpretation = C.VIPS_INTERPRETATION_MATRIX
 	InterpretationScRGB     Interpretation = C.VIPS_INTERPRETATION_scRGB


### PR DESCRIPTION
`InterpretationGB16` is set to `C.VIPS_INTERPRETATION_RGB16` instead of `C.VIPS_INTERPRETATION_GB16`