### PR TITLE
Support image_insert()

### DIFF
--- a/vips/conversion.c
+++ b/vips/conversion.c
@@ -148,3 +148,14 @@ int composite2_image(VipsImage *base, VipsImage *overlay, VipsImage **out,
                      int mode, gint x, gint y) {
   return vips_composite2(base, overlay, out, mode, "x", x, "y", y, NULL);
 }
+
+int insert_image(VipsImage *main, VipsImage *sub, VipsImage **out, int x, int y, int expand, int background) {
+  VipsArrayDouble *vipsBackground;
+  double r = (background & 0xff0000) >> 16;
+  double g = (background & 0x00ff00) >> 8;
+  double b = (background & 0x0000ff) >> 0;
+  double background_arr[3] = {r, g, b};
+  vipsBackground = vips_array_double_new(background_arr, 3);
+
+  return vips_insert(main, sub, out, x, y, "expand", 0, "background", vipsBackground, NULL);
+}

--- a/vips/conversion.go
+++ b/vips/conversion.go
@@ -119,6 +119,11 @@ const (
 	InterestingLast      Interesting = C.VIPS_INTERESTING_LAST
 )
 
+type InsertOptionalArgs struct {
+	Expand     int
+	Background int
+}
+
 // https://libvips.github.io/libvips/API/current/libvips-conversion.html#vips-copy
 func vipsCopyImage(in *C.VipsImage) (*C.VipsImage, error) {
 	var out *C.VipsImage
@@ -342,6 +347,17 @@ func vipsComposite2(base *C.VipsImage, overlay *C.VipsImage, mode BlendMode, x, 
 	var out *C.VipsImage
 
 	if err := C.composite2_image(base, overlay, &out, C.int(mode), C.gint(x), C.gint(y)); err != 0 {
+		return nil, handleImageError(out)
+	}
+
+	return out, nil
+}
+
+func vipsInsert(main *C.VipsImage, sub *C.VipsImage, x, y int, opts InsertOptionalArgs) (*C.VipsImage, error) {
+	incOpCounter("insert")
+	var out *C.VipsImage
+
+	if err := C.insert_image(main, sub, &out, C.int(x), C.int(y), C.int(opts.Expand), C.int(opts.Background)); err != 0 {
 		return nil, handleImageError(out)
 	}
 

--- a/vips/conversion.go
+++ b/vips/conversion.go
@@ -119,11 +119,6 @@ const (
 	InterestingLast      Interesting = C.VIPS_INTERESTING_LAST
 )
 
-type InsertOptionalArguments struct {
-	Expand     bool
-	Background ColorRGBA
-}
-
 // https://libvips.github.io/libvips/API/current/libvips-conversion.html#vips-copy
 func vipsCopyImage(in *C.VipsImage) (*C.VipsImage, error) {
 	var out *C.VipsImage
@@ -353,14 +348,16 @@ func vipsComposite2(base *C.VipsImage, overlay *C.VipsImage, mode BlendMode, x, 
 	return out, nil
 }
 
-func vipsInsert(main *C.VipsImage, sub *C.VipsImage, x, y int, opts *InsertOptionalArguments) (*C.VipsImage, error) {
+func vipsInsert(main *C.VipsImage, sub *C.VipsImage, x, y int, expand bool, background *ColorRGBA) (*C.VipsImage, error) {
 	incOpCounter("insert")
 	var out *C.VipsImage
 
-	background := opts.Background
+	if background == nil {
+		background = &ColorRGBA{R: 0.0, G: 0.0, B: 0.0, A: 255.0}
+	}
 
 	expandInt := 0
-	if opts.Expand {
+	if expand {
 		expandInt = 1
 	}
 

--- a/vips/conversion.go
+++ b/vips/conversion.go
@@ -119,9 +119,9 @@ const (
 	InterestingLast      Interesting = C.VIPS_INTERESTING_LAST
 )
 
-type InsertOptionalArgs struct {
-	Expand     int
-	Background int
+type InsertOptionalArguments struct {
+	Expand     bool
+	Background ColorRGBA
 }
 
 // https://libvips.github.io/libvips/API/current/libvips-conversion.html#vips-copy
@@ -353,11 +353,18 @@ func vipsComposite2(base *C.VipsImage, overlay *C.VipsImage, mode BlendMode, x, 
 	return out, nil
 }
 
-func vipsInsert(main *C.VipsImage, sub *C.VipsImage, x, y int, opts InsertOptionalArgs) (*C.VipsImage, error) {
+func vipsInsert(main *C.VipsImage, sub *C.VipsImage, x, y int, opts *InsertOptionalArguments) (*C.VipsImage, error) {
 	incOpCounter("insert")
 	var out *C.VipsImage
 
-	if err := C.insert_image(main, sub, &out, C.int(x), C.int(y), C.int(opts.Expand), C.int(opts.Background)); err != 0 {
+	background := opts.Background
+
+	expandInt := 0
+	if opts.Expand {
+		expandInt = 1
+	}
+
+	if err := C.insert_image(main, sub, &out, C.int(x), C.int(y), C.int(expandInt), C.double(background.R), C.double(background.G), C.double(background.B), C.double(background.A)); err != 0 {
 		return nil, handleImageError(out)
 	}
 

--- a/vips/conversion.h
+++ b/vips/conversion.h
@@ -40,6 +40,6 @@ int composite2_image(VipsImage *base, VipsImage *overlay, VipsImage **out,
                      int mode, gint x, gint y);
 
 int insert_image(VipsImage *main, VipsImage *sub, VipsImage **out, int x, int y,
-                 int expand, int background);
+                 int expand, double r, double g, double b, double a);
 
 int is_16bit(VipsInterpretation interpretation);

--- a/vips/conversion.h
+++ b/vips/conversion.h
@@ -39,4 +39,7 @@ int composite_image(VipsImage **in, VipsImage **out, int n, int *mode, int *x,
 int composite2_image(VipsImage *base, VipsImage *overlay, VipsImage **out,
                      int mode, gint x, gint y);
 
+int insert_image(VipsImage *main, VipsImage *sub, VipsImage **out, int x, int y,
+                 int expand, int background);
+
 int is_16bit(VipsInterpretation interpretation);

--- a/vips/image.go
+++ b/vips/image.go
@@ -603,7 +603,7 @@ func (r *ImageRef) Composite(overlay *ImageRef, mode BlendMode, x, y int) error 
 	return nil
 }
 
-// Composite composites the given overlay image on top of the associated image with provided blending mode.
+// Insert draws the image on top of the associated image at the given coordinates.
 func (r *ImageRef) Insert(sub *ImageRef, x, y, expand, background int) error {
 	out, err := vipsInsert(r.image, sub.image, x, y, InsertOptionalArgs{Expand: expand, Background: background})
 	if err != nil {

--- a/vips/image.go
+++ b/vips/image.go
@@ -603,6 +603,16 @@ func (r *ImageRef) Composite(overlay *ImageRef, mode BlendMode, x, y int) error 
 	return nil
 }
 
+// Composite composites the given overlay image on top of the associated image with provided blending mode.
+func (r *ImageRef) Insert(sub *ImageRef, x, y, expand, background int) error {
+	out, err := vipsInsert(r.image, sub.image, x, y, InsertOptionalArgs{Expand: expand, Background: background})
+	if err != nil {
+		return err
+	}
+	r.setImage(out)
+	return nil
+}
+
 // Mapim resamples an image using index to look up pixels
 func (r *ImageRef) Mapim(index *ImageRef) error {
 	out, err := vipsMapim(r.image, index.image)

--- a/vips/image.go
+++ b/vips/image.go
@@ -604,8 +604,8 @@ func (r *ImageRef) Composite(overlay *ImageRef, mode BlendMode, x, y int) error 
 }
 
 // Insert draws the image on top of the associated image at the given coordinates.
-func (r *ImageRef) Insert(sub *ImageRef, x, y, expand, background int) error {
-	out, err := vipsInsert(r.image, sub.image, x, y, InsertOptionalArgs{Expand: expand, Background: background})
+func (r *ImageRef) Insert(sub *ImageRef, x, y int, opts *InsertOptionalArguments) error {
+	out, err := vipsInsert(r.image, sub.image, x, y, opts)
 	if err != nil {
 		return err
 	}

--- a/vips/image.go
+++ b/vips/image.go
@@ -604,8 +604,8 @@ func (r *ImageRef) Composite(overlay *ImageRef, mode BlendMode, x, y int) error 
 }
 
 // Insert draws the image on top of the associated image at the given coordinates.
-func (r *ImageRef) Insert(sub *ImageRef, x, y int, opts *InsertOptionalArguments) error {
-	out, err := vipsInsert(r.image, sub.image, x, y, opts)
+func (r *ImageRef) Insert(sub *ImageRef, x, y int, expand bool, background *ColorRGBA) error {
+	out, err := vipsInsert(r.image, sub.image, x, y, expand, background)
 	if err != nil {
 		return err
 	}

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -485,10 +485,7 @@ func TestImageRef_Insert(t *testing.T) {
 	imageOverlay, err := NewImageFromFile(resources + "png-24bit.png")
 	require.NoError(t, err)
 
-	err = image.Insert(imageOverlay, 100, 200, &InsertOptionalArguments{
-		Background: ColorRGBA{R: 255.0, G: 0.0, B: 255.0, A: 255.0},
-		Expand:     false,
-	})
+	err = image.Insert(imageOverlay, 100, 200, false, nil)
 	require.NoError(t, err)
 }
 

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -476,6 +476,19 @@ func TestImageRef_Composite(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestImageRef_Insert(t *testing.T) {
+	Startup(nil)
+
+	image, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+
+	imageOverlay, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+
+	err = image.Insert(imageOverlay, 10, 20, 0, 0)
+	require.NoError(t, err)
+}
+
 func TestImageRef_Mapim(t *testing.T) {
 	Startup(nil)
 

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -485,7 +485,10 @@ func TestImageRef_Insert(t *testing.T) {
 	imageOverlay, err := NewImageFromFile(resources + "png-24bit.png")
 	require.NoError(t, err)
 
-	err = image.Insert(imageOverlay, 10, 20, 0, 0)
+	err = image.Insert(imageOverlay, 100, 200, &InsertOptionalArguments{
+		Background: ColorRGBA{R: 255.0, G: 0.0, B: 255.0, A: 255.0},
+		Expand:     false,
+	})
 	require.NoError(t, err)
 }
 
@@ -835,7 +838,7 @@ func TestImageRef_FindTrim_Threshold(t *testing.T) {
 func TestImageRef_Linear_Fails(t *testing.T) {
 	image, err := NewImageFromFile(resources + "png-24bit.png")
 	assert.NoError(t, err)
-	err = image.Linear([]float64{1,2}, []float64{1,2,3})
+	err = image.Linear([]float64{1, 2}, []float64{1, 2, 3})
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
I was porting some code that relied on ruby-vips, and it used the `insert()` operation. When I saw that wasn't available in govips, I tried using `Composite2()` with the ATOP blend mode, and that kind of worked, though I suspect not exactly, and it was about ~30%~ 80% slower than using `insert()`. So I decided to add support for `insert()`!

These changes worked for me, but I'm not totally sure I've followed all the appropriate patterns. Let me know if there are pieces I should change and I'll get it updated.