### PR TITLE
Propagate the return value from vips_object_set

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -95,7 +95,7 @@ int save_buffer(const char *operationName, SaveParams *params,
 // https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-jpegsave-buffer
 int set_jpeg_options(VipsOperation *operation, SaveParams *params)
 {
-  vips_object_set(VIPS_OBJECT(operation),
+  int ret = vips_object_set(VIPS_OBJECT(operation),
                   "strip", params->stripMetadata,
                   "optimize_coding", params->jpegOptimizeCoding,
                   "interlace", params->interlace,
@@ -106,27 +106,27 @@ int set_jpeg_options(VipsOperation *operation, SaveParams *params)
                   "quant_table", params->jpegQuantTable,
                   NULL);
 
-  if (params->quality)
+  if (!ret && params->quality)
   {
-    vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
+    ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  // TODO add return value or change function to void
+  return ret;
 }
 
 // https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-pngsave-buffer
 int set_png_options(VipsOperation *operation, SaveParams *params)
 {
-  vips_object_set(VIPS_OBJECT(operation), "strip", params->stripMetadata,
+  int ret = vips_object_set(VIPS_OBJECT(operation), "strip", params->stripMetadata,
                   "compression", params->pngCompression, "interlace",
                   params->interlace, "filter", params->pngFilter, NULL);
 
-  if (params->quality)
+  if (!ret && params->quality)
   {
-    vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
+    ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  // TODO add return value or change function to void
+  return ret;
 }
 
 // todo: support additional params
@@ -134,49 +134,49 @@ int set_png_options(VipsOperation *operation, SaveParams *params)
 // https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-webpsave-buffer
 int set_webp_options(VipsOperation *operation, SaveParams *params)
 {
-  vips_object_set(VIPS_OBJECT(operation), "strip", params->stripMetadata,
+  int ret = vips_object_set(VIPS_OBJECT(operation), "strip", params->stripMetadata,
                   "lossless", params->webpLossless, "reduction_effort",
                   params->webpReductionEffort, NULL);
 
-  if (params->quality)
+  if (!ret && params->quality)
   {
-    vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
+    ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  // TODO add return value or change function to void
+  return ret;
 }
 
 // todo: support additional params
 // https://github.com/libvips/libvips/blob/master/libvips/foreign/heifsave.c#L653
 int set_heif_options(VipsOperation *operation, SaveParams *params)
 {
-  vips_object_set(VIPS_OBJECT(operation), "lossless", params->heifLossless,
+  int ret = vips_object_set(VIPS_OBJECT(operation), "lossless", params->heifLossless,
                   NULL);
 
-  if (params->quality)
+  if (!ret && params->quality)
   {
-    vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
+    ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  // TODO add return value or change function to void
+  return ret;
 }
 
 // https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-tiffsave-buffer
 int set_tiff_options(VipsOperation *operation, SaveParams *params)
 {
-  vips_object_set(VIPS_OBJECT(operation), "strip", params->stripMetadata,
+  int ret = vips_object_set(VIPS_OBJECT(operation), "strip", params->stripMetadata,
                   "compression", params->tiffCompression, "predictor",
                   params->tiffPredictor, "pyramid", params->tiffPyramid,
                   "tile_height", params->tiffTileHeight, "tile_width",
                   params->tiffTileWidth, "tile", params->tiffTile, "xres",
                   params->tiffXRes, "yres", params->tiffYRes, NULL);
 
-  if (params->quality)
+  if (!ret && params->quality)
   {
-    vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
+    ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  // TODO add return value or change function to void
+  return ret;
 }
 
 int save_to_buffer(SaveParams *params)


### PR DESCRIPTION
This PR propagates the return code of calls to `vips_object_set` in `set_xxx_options` functions.  
As a result, the following compiler warnings (on macOS) disappear:
```
foreign.c:115:1: warning: non-void function does not return a value [-Wreturn-type]
foreign.c:130:1: warning: non-void function does not return a value [-Wreturn-type]
foreign.c:147:1: warning: non-void function does not return a value [-Wreturn-type]
foreign.c:162:1: warning: non-void function does not return a value [-Wreturn-type]
foreign.c:180:1: warning: non-void function does not return a value [-Wreturn-type]
```
I am not quite sure how to write tests for these changes. Hints or remarks are welcome!