### PR TITLE
Add `MALLOC_ARENA_MAX` to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ See _examples/_ folder for more examples.
 $ make test
 ```
 
+## Memory usage note
+### MALLOC_ARENA_MAX
+`libvips` uses GLib for memory management, and it brings GLib memory fragmentation
+issues to heavily multi-threaded programs. First thing you can try if you noticed
+constantly growing RSS usage without Go's sys memory growth is set `MALLOC_ARENA_MAX`:
+
+```
+MALLOC_ARENA_MAX=2 application
+```
+
+This will reduce GLib memory appetites by reducing the number of malloc arenas
+that it can create. By default GLib creates one are per thread, and this would
+follow to a memory fragmentation.
+
 ## Contributing
 
 Feel free to file issues or create pull requests. See this [guide on contributing](https://github.com/davidbyttow/govips/blob/master/CONTRIBUTING.md) for more information.


### PR DESCRIPTION
It took me a long time to find the cause of the abnormally high memory usage. It helped just to set the variable `MALLOC_ARENA_MAX=2`.

Text copied from: https://github.com/imgproxy/imgproxy/blob/master/docs/memory_usage_tweaks.md#malloc_arena_max

See also:
 - https://github.com/prestodb/presto/issues/8993
 - https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html