### PR TITLE
Add respect `fail` parameter to `pngload`

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -93,6 +93,7 @@ int set_jpegload_options(VipsOperation *operation, LoadParams *params) {
 }
 
 int set_pngload_options(VipsOperation *operation, LoadParams *params) {
+  MAYBE_SET_BOOL(operation, params->fail, "fail");
   return 0;
 }
 


### PR DESCRIPTION
`pngload` actually has `fail` option support, although this is not reflected in the documentation.
