### PR TITLE
Add missing PNG export params

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -239,11 +239,22 @@ int set_pngsave_options(VipsOperation *operation, SaveParams *params) {
   int ret =
       vips_object_set(VIPS_OBJECT(operation), "strip", params->stripMetadata,
                       "compression", params->pngCompression, "interlace",
-                      params->interlace, "filter", params->pngFilter, NULL);
+                      params->interlace, "filter", params->pngFilter, "palette",
+                      params->pngPalette, NULL);
 
   if (!ret && params->quality) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
+
+  if (!ret && params->pngDither) {
+    ret = vips_object_set(VIPS_OBJECT(operation), "dither", params->pngDither, NULL);
+  }
+
+  if (!ret && params->pngBitdepth) {
+    ret = vips_object_set(VIPS_OBJECT(operation), "bitdepth", params->pngBitdepth, NULL);
+  }
+
+  // TODO: Handle `profile` param.
 
   return ret;
 }
@@ -411,6 +422,9 @@ static SaveParams defaultSaveParams = {
     .jpegQuantTable = 0,
 
     .pngCompression = 6,
+    .pngPalette = FALSE,
+    .pngBitdepth = 0,
+    .pngDither = 0,
     .pngFilter = VIPS_FOREIGN_PNG_FILTER_NONE,
 
     .webpLossless = FALSE,

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -327,9 +327,13 @@ func vipsSavePNGToBuffer(in *C.VipsImage, params PngExportParams) ([]byte, error
 
 	p := C.create_save_params(C.PNG)
 	p.inputImage = in
+	p.quality = C.int(params.Quality)
 	p.stripMetadata = C.int(boolToInt(params.StripMetadata))
 	p.interlace = C.int(boolToInt(params.Interlace))
 	p.pngCompression = C.int(params.Compression)
+	p.pngPalette = C.int(boolToInt(params.Palette))
+	p.pngDither = C.double(params.Dither)
+	p.pngBitdepth = C.int(params.Bitdepth)
 
 	return vipsSaveToBuffer(p)
 }

--- a/vips/foreign.h
+++ b/vips/foreign.h
@@ -36,7 +36,7 @@ typedef enum ParamType {
 
 typedef struct Param {
   ParamType type;
-  
+
   union Value {
     gboolean b;
     gint i;
@@ -91,6 +91,9 @@ typedef struct SaveParams {
   // PNG
   int pngCompression;
   VipsForeignPngFilter pngFilter;
+  BOOL pngPalette;
+  double pngDither;
+  int pngBitdepth;
 
   // WEBP
   BOOL webpLossless;

--- a/vips/image.go
+++ b/vips/image.go
@@ -209,6 +209,11 @@ type PngExportParams struct {
 	StripMetadata bool
 	Compression   int
 	Interlace     bool
+	Quality       int
+	Palette       bool
+	Dither        float64
+	Bitdepth      int
+	Profile       string // TODO: Use this param during save
 }
 
 // NewPngExportParams creates default values for an export of a PNG image.
@@ -217,6 +222,7 @@ func NewPngExportParams() *PngExportParams {
 	return &PngExportParams{
 		Compression: 6,
 		Interlace:   false,
+		Palette:     false,
 	}
 }
 


### PR DESCRIPTION
The params `palette`, `Q`, `dither`, `bitdepth` and `profile` were not used or not mapped in `vips.PngExportParams`.

This PR adds support for them.

**Note:** I don't know how to convert a Go `string` (for `profile`) to the C equivalent. Does anybody know?

Ref: https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-pngsave