### PR TITLE
Fix a broken format of how to run tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ The CI/CD currently checks strict format and linting, so be sure to add comments
 
 ## Run the tests
 
-```make test
+```bash
+$ make test
 ```
 
 ## Get in touch


### PR DESCRIPTION
This fixed a broken format of how to run tests in CONTRIBUTING.md.

**Before** (https://github.com/davidbyttow/govips/blob/master/CONTRIBUTING.md#run-the-tests)

![image](https://user-images.githubusercontent.com/987638/143325547-ed3935d0-20f6-4521-8d2f-d7b9b0013c11.png)

**After**

![image](https://user-images.githubusercontent.com/987638/143325576-aa81e3d1-0537-4a4c-ba48-34e2b5111558.png)
