### PR TITLE
Fix double free of initial *VipsImage object in Label()

### DIFF
--- a/vips/label.c
+++ b/vips/label.c
@@ -12,7 +12,7 @@ int label(VipsImage *in, VipsImage **out, LabelOptions *o) {
   VipsImage **t = (VipsImage **)vips_object_local_array(VIPS_OBJECT(base), 9);
   if (vips_text(&t[0], o->Text, "font", o->Font, "width", o->Width, "height",
                 o->Height, "align", o->Align, NULL) ||
-      vips_linear1(t[1], &t[2], o->Opacity, 0.0, NULL) ||
+      vips_linear1(t[0], &t[1], o->Opacity, 0.0, NULL) ||
       vips_cast(t[1], &t[2], VIPS_FORMAT_UCHAR, NULL) ||
       vips_embed(t[2], &t[3], o->OffsetX, o->OffsetY, t[2]->Xsize + o->OffsetX,
                  t[2]->Ysize + o->OffsetY, NULL)) {

--- a/vips/label.c
+++ b/vips/label.c
@@ -9,27 +9,26 @@ int text(VipsImage **out, const char *text, const char *font, int width,
 int label(VipsImage *in, VipsImage **out, LabelOptions *o) {
   double ones[3] = {1, 1, 1};
   VipsImage *base = vips_image_new();
-  VipsImage **t = (VipsImage **)vips_object_local_array(VIPS_OBJECT(base), 10);
-  t[0] = in;
-  if (vips_text(&t[1], o->Text, "font", o->Font, "width", o->Width, "height",
+  VipsImage **t = (VipsImage **)vips_object_local_array(VIPS_OBJECT(base), 9);
+  if (vips_text(&t[0], o->Text, "font", o->Font, "width", o->Width, "height",
                 o->Height, "align", o->Align, NULL) ||
       vips_linear1(t[1], &t[2], o->Opacity, 0.0, NULL) ||
-      vips_cast(t[2], &t[3], VIPS_FORMAT_UCHAR, NULL) ||
-      vips_embed(t[3], &t[4], o->OffsetX, o->OffsetY, t[3]->Xsize + o->OffsetX,
-                 t[3]->Ysize + o->OffsetY, NULL)) {
+      vips_cast(t[1], &t[2], VIPS_FORMAT_UCHAR, NULL) ||
+      vips_embed(t[2], &t[3], o->OffsetX, o->OffsetY, t[2]->Xsize + o->OffsetX,
+                 t[2]->Ysize + o->OffsetY, NULL)) {
     g_object_unref(base);
     return 1;
   }
-  if (vips_black(&t[5], 1, 1, NULL) ||
-      vips_linear(t[5], &t[6], ones, o->Color, 3, NULL) ||
-      vips_cast(t[6], &t[7], VIPS_FORMAT_UCHAR, NULL) ||
-      vips_copy(t[7], &t[8], "interpretation", t[0]->Type, NULL) ||
-      vips_embed(t[8], &t[9], 0, 0, t[0]->Xsize, t[0]->Ysize, "extend",
+  if (vips_black(&t[4], 1, 1, NULL) ||
+      vips_linear(t[4], &t[5], ones, o->Color, 3, NULL) ||
+      vips_cast(t[5], &t[6], VIPS_FORMAT_UCHAR, NULL) ||
+      vips_copy(t[6], &t[7], "interpretation", in->Type, NULL) ||
+      vips_embed(t[7], &t[8], 0, 0, in->Xsize, in->Ysize, "extend",
                  VIPS_EXTEND_COPY, NULL)) {
     g_object_unref(base);
     return 1;
   }
-  if (vips_ifthenelse(t[4], t[9], t[0], out, "blend", TRUE, NULL)) {
+  if (vips_ifthenelse(t[3], t[8], in, out, "blend", TRUE, NULL)) {
     g_object_unref(base);
     return 1;
   }


### PR DESCRIPTION
Initial *VipsImage is freed twice in Label() method: first time when calling [g_object_unref(base)](https://github.com/davidbyttow/govips/blob/master/vips/label.c#L36) and second time in [setImage()](https://github.com/davidbyttow/govips/blob/56a7f514cfcb41699a11a5116859e4d93078fd9c/vips/image.go#L1466).
It leads to errors in logs:
`[GLib-GObject.critical] g_object_unref: assertion 'G_IS_OBJECT (object)' failed`
Also segmentation violations occasionally happen.