### PR TITLE
DetermineImageType by first 512 bytes

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -139,14 +139,14 @@ func DetermineImageType(buf []byte) ImageType {
 		return ImageTypeAVIF
 	} else if isHEIF(buf) {
 		return ImageTypeHEIF
+	} else if isSVG(buf) {
+		return ImageTypeSVG
 	} else if isPDF(buf) {
 		return ImageTypePDF
 	} else if isBMP(buf) {
 		return ImageTypeBMP
 	} else if isJP2K(buf) {
 		return ImageTypeJP2K
-	} else if isSVG(buf) {
-		return ImageTypeSVG
 	} else {
 		return ImageTypeUnknown
 	}

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -120,12 +120,14 @@ const sniffLen = 512
 
 // DetermineImageType attempts to determine the image type of the given buffer
 func DetermineImageType(buf []byte) ImageType {
-	if len(buf) > sniffLen {
+	ln := len(buf)
+	if ln < 12 {
+		return ImageTypeUnknown
+	}
+	if ln > sniffLen {
 		buf = buf[:sniffLen]
 	}
-	if len(buf) < 12 {
-		return ImageTypeUnknown
-	} else if isJPEG(buf) {
+	if isJPEG(buf) {
 		return ImageTypeJPEG
 	} else if isPNG(buf) {
 		return ImageTypePNG

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -7,7 +7,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"image/png"
-	"math"
 	"runtime"
 	"unsafe"
 
@@ -117,8 +116,14 @@ func IsTypeSupported(imageType ImageType) bool {
 	return supportedImageTypes[imageType]
 }
 
+// uses at most sniffLen bytes to make its decision.
+const sniffLen = 1024
+
 // DetermineImageType attempts to determine the image type of the given buffer
 func DetermineImageType(buf []byte) ImageType {
+	if len(buf) > sniffLen {
+		buf = buf[:sniffLen]
+	}
 	if len(buf) < 12 {
 		return ImageTypeUnknown
 	} else if isJPEG(buf) {
@@ -200,8 +205,7 @@ func isAVIF(buf []byte) bool {
 var svg = []byte("<svg")
 
 func isSVG(buf []byte) bool {
-	sub := buf[:int(math.Min(1024.0, float64(len(buf))))]
-	if bytes.Contains(sub, svg) {
+	if bytes.Contains(buf, svg) {
 		data := &struct {
 			XMLName xml.Name `xml:"svg"`
 		}{}


### PR DESCRIPTION
This changes is about slightly optimizing `DetermineImageType`, 
by taking only the first 512 bytes to determine image type