### PR TITLE
Remove deprecated export functions

### DIFF
--- a/examples/logging/example_logging_test.go
+++ b/examples/logging/example_logging_test.go
@@ -62,8 +62,7 @@ func main() {
 	checkError(err)
 	myLogger("loggingExample", vips.LogLevelInfo, fmt.Sprintf("Before: %v x %v", image1.Height(), image1.Width()))
 
-	ep := vips.NewDefaultJPEGExportParams()
-	image1bytes, _, err := image1.Export(ep)
+	image1bytes, _, err := image1.ExportJpeg(nil)
 	checkError(err)
 	err = ioutil.WriteFile("output.jpg", image1bytes, 0644)
 	checkError(err)

--- a/examples/tiff/example_tiff_image.go
+++ b/examples/tiff/example_tiff_image.go
@@ -30,10 +30,9 @@ func main() {
 	checkError(err)
 	fmt.Println(inputImage.Height(), inputImage.Width())
 
-	ep := vips.NewDefaultExportParams()
-	ep.Format = vips.ImageTypeTIFF
-	ep.Quality = 100
-	imageBytes, _, err := inputImage.Export(ep)
+	exportParams := vips.NewTiffExportParams()
+	exportParams.Quality = 100
+	imageBytes, _, err := inputImage.ExportTiff(exportParams)
 	err = ioutil.WriteFile("examples/tiff/output-govips.tiff", imageBytes, 0644)
 	checkError(err)
 }

--- a/vips/image.go
+++ b/vips/image.go
@@ -115,75 +115,6 @@ func NewImportParams() *ImportParams {
 	return p
 }
 
-// ExportParams are options when exporting an image to file or buffer.
-// Deprecated: Use format-specific params
-type ExportParams struct {
-	Format             ImageType
-	Quality            int
-	Compression        int
-	Interlaced         bool
-	Lossless           bool
-	Effort             int
-	StripMetadata      bool
-	OptimizeCoding     bool          // jpeg param
-	SubsampleMode      SubsampleMode // jpeg param
-	TrellisQuant       bool          // jpeg param
-	OvershootDeringing bool          // jpeg param
-	OptimizeScans      bool          // jpeg param
-	QuantTable         int           // jpeg param
-	Speed              int           // avif param
-}
-
-// NewDefaultExportParams creates default values for an export when image type is not JPEG, PNG or WEBP.
-// By default, govips creates interlaced, lossy images with a quality of 80/100 and compression of 6/10.
-// As these are default values for a wide variety of image formats, their application varies.
-// Some formats use the quality parameters, some compression, etc.
-// Deprecated: Use format-specific params
-func NewDefaultExportParams() *ExportParams {
-	return &ExportParams{
-		Format:      ImageTypeUnknown, // defaults to the starting encoder
-		Quality:     80,
-		Compression: 6,
-		Interlaced:  true,
-		Lossless:    false,
-		Effort:      4,
-	}
-}
-
-// NewDefaultJPEGExportParams creates default values for an export of a JPEG image.
-// By default, govips creates interlaced JPEGs with a quality of 80/100.
-// Deprecated: Use NewJpegExportParams
-func NewDefaultJPEGExportParams() *ExportParams {
-	return &ExportParams{
-		Format:     ImageTypeJPEG,
-		Quality:    80,
-		Interlaced: true,
-	}
-}
-
-// NewDefaultPNGExportParams creates default values for an export of a PNG image.
-// By default, govips creates non-interlaced PNGs with a compression of 6/10.
-// Deprecated: Use NewPngExportParams
-func NewDefaultPNGExportParams() *ExportParams {
-	return &ExportParams{
-		Format:      ImageTypePNG,
-		Compression: 6,
-		Interlaced:  false,
-	}
-}
-
-// NewDefaultWEBPExportParams creates default values for an export of a WEBP image.
-// By default, govips creates lossy images with a quality of 75/100.
-// Deprecated: Use NewWebpExportParams
-func NewDefaultWEBPExportParams() *ExportParams {
-	return &ExportParams{
-		Format:   ImageTypeWEBP,
-		Quality:  75,
-		Lossless: false,
-		Effort:   4,
-	}
-}
-
 // JpegExportParams are options when exporting a JPEG to file or buffer
 type JpegExportParams struct {
 	StripMetadata      bool
@@ -455,8 +386,8 @@ func (r *ImageRef) Copy() (*ImageRef, error) {
 // XYZ creates a two-band uint32 image where the elements in the first band have the value of their x coordinate
 // and elements in the second band have their y coordinate.
 func XYZ(width, height int) (*ImageRef, error) {
-	image, err := vipsXYZ(width, height)
-	return &ImageRef{image: image}, err
+	vipsImage, err := vipsXYZ(width, height)
+	return &ImageRef{image: vipsImage}, err
 }
 
 // Identity creates an identity lookup table, which will leave an image unchanged when applied with Maplut.
@@ -468,18 +399,18 @@ func Identity(ushort bool) (*ImageRef, error) {
 
 // Black creates a new black image of the specified size
 func Black(width, height int) (*ImageRef, error) {
-	image, err := vipsBlack(width, height)
-	return &ImageRef{image: image}, err
+	vipsImage, err := vipsBlack(width, height)
+	return &ImageRef{image: vipsImage}, err
 }
 
 func newImageRef(vipsImage *C.VipsImage, format ImageType, buf []byte) *ImageRef {
-	image := &ImageRef{
+	imageRef := &ImageRef{
 		image:  vipsImage,
 		format: format,
 		buf:    buf,
 	}
-	runtime.SetFinalizer(image, finalizeImage)
-	return image
+	runtime.SetFinalizer(imageRef, finalizeImage)
+	return imageRef
 }
 
 func finalizeImage(ref *ImageRef) {
@@ -632,78 +563,6 @@ func (r *ImageRef) newMetadata(format ImageType) *ImageMetadata {
 // GetPages returns the number of Image
 func (r *ImageRef) GetPages() int {
 	return vipsImageGetPages(r.image)
-}
-
-// Export creates a byte array of the image for use.
-// The function returns a byte array that can be written to a file e.g. via ioutil.WriteFile().
-// N.B. govips does not currently have built-in support for directly exporting to a file.
-// The function also returns a copy of the image metadata as well as an error.
-// Deprecated: Use ExportNative or format-specific Export methods
-func (r *ImageRef) Export(params *ExportParams) ([]byte, *ImageMetadata, error) {
-	if params == nil || params.Format == ImageTypeUnknown {
-		return r.ExportNative()
-	}
-
-	format := params.Format
-
-	if !IsTypeSupported(format) {
-		return nil, r.newMetadata(ImageTypeUnknown), fmt.Errorf("cannot save to %#v", ImageTypes[format])
-	}
-
-	switch format {
-	case ImageTypeGIF:
-		return r.ExportGIF(&GifExportParams{
-			Quality: params.Quality,
-		})
-	case ImageTypeWEBP:
-		return r.ExportWebp(&WebpExportParams{
-			StripMetadata:   params.StripMetadata,
-			Quality:         params.Quality,
-			Lossless:        params.Lossless,
-			ReductionEffort: params.Effort,
-		})
-	case ImageTypePNG:
-		return r.ExportPng(&PngExportParams{
-			StripMetadata: params.StripMetadata,
-			Compression:   params.Compression,
-			Interlace:     params.Interlaced,
-		})
-	case ImageTypeTIFF:
-		compression := TiffCompressionLzw
-		if params.Lossless {
-			compression = TiffCompressionNone
-		}
-		return r.ExportTiff(&TiffExportParams{
-			StripMetadata: params.StripMetadata,
-			Quality:       params.Quality,
-			Compression:   compression,
-		})
-	case ImageTypeHEIF:
-		return r.ExportHeif(&HeifExportParams{
-			Quality:  params.Quality,
-			Lossless: params.Lossless,
-		})
-	case ImageTypeAVIF:
-		return r.ExportAvif(&AvifExportParams{
-			StripMetadata: params.StripMetadata,
-			Quality:       params.Quality,
-			Lossless:      params.Lossless,
-			Speed:         params.Speed,
-		})
-	default:
-		format = ImageTypeJPEG
-		return r.ExportJpeg(&JpegExportParams{
-			Quality:            params.Quality,
-			StripMetadata:      params.StripMetadata,
-			Interlace:          params.Interlaced,
-			OptimizeCoding:     params.OptimizeCoding,
-			SubsampleMode:      params.SubsampleMode,
-			TrellisQuant:       params.TrellisQuant,
-			OvershootDeringing: params.OvershootDeringing,
-			OptimizeScans:      params.OptimizeScans,
-			QuantTable:         params.QuantTable,
-		})
-	}
 }
 
 // ExportNative exports the image to a buffer based on its native format with default parameters.
@@ -1536,8 +1395,11 @@ func (r *ImageRef) determineInputICCProfile() (inputProfile string) {
 }
 
 // ToImage converts a VIPs image to a golang image.Image object, useful for interoperability with other golang libraries
-func (r *ImageRef) ToImage(params *ExportParams) (image.Image, error) {
-	imageBytes, _, err := r.Export(params)
+func (r *ImageRef) ToImage() (image.Image, error) {
+	// export to lossless PNG - PNG is guaranteed to be supported natively in Go
+	params := NewPngExportParams()
+	params.Compression = 0
+	imageBytes, _, err := r.ExportPng(params)
 	if err != nil {
 		return nil, err
 	}

--- a/vips/image_golden_test.go
+++ b/vips/image_golden_test.go
@@ -683,7 +683,7 @@ func TestImage_SimilarityRGBA(t *testing.T) {
 
 func TestImage_Decode_JPG(t *testing.T) {
 	goldenTest(t, resources+"jpg-24bit.jpg", func(img *ImageRef) error {
-		goImg, err := img.ToImage(nil)
+		goImg, err := img.ToImage()
 		assert.NoError(t, err)
 
 		buf := new(bytes.Buffer)
@@ -702,7 +702,7 @@ func TestImage_Decode_JPG(t *testing.T) {
 
 func TestImage_Decode_BMP(t *testing.T) {
 	goldenTest(t, resources+"bmp.bmp", func(img *ImageRef) error {
-		goImg, err := img.ToImage(nil)
+		goImg, err := img.ToImage()
 		assert.NoError(t, err)
 
 		buf := new(bytes.Buffer)
@@ -721,7 +721,7 @@ func TestImage_Decode_BMP(t *testing.T) {
 
 func TestImage_Decode_PNG(t *testing.T) {
 	goldenTest(t, resources+"png-8bit.png", func(img *ImageRef) error {
-		goImg, err := img.ToImage(nil)
+		goImg, err := img.ToImage()
 		assert.NoError(t, err)
 
 		buf := new(bytes.Buffer)


### PR DESCRIPTION
ToImage() always passes through PNG as it is guaranteed to be supported and lossless