### PR TITLE
Default to using gifsave for libvips >= 8.12.0

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -329,9 +329,17 @@ int set_magicksave_options(VipsOperation *operation, SaveParams *params) {
 
 // https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-gifsave-buffer
 int set_gifsave_options(VipsOperation *operation, SaveParams *params) {
-  // TODO: Set optional arguments?
-  //  int ret = vips_object_set(VIPS_OBJECT(operation), "quality", params->quality, NULL);
   int ret = 0;
+  // See for argument values: https://www.libvips.org/API/current/VipsForeignSave.html#vips-gifsave
+  if (params->gifDither > 0.0 && params->gifDither <= 1.0) {
+    ret = vips_object_set(VIPS_OBJECT(operation), "dither", params->gifDither, NULL);
+  }
+  if (params->gifEffort >= 1 && params->gifEffort <= 10) {
+    ret = vips_object_set(VIPS_OBJECT(operation), "effort", params->gifEffort, NULL);
+  }
+  if (params->gifBitdepth >= 1 && params->gifBitdepth <= 8) {
+      ret = vips_object_set(VIPS_OBJECT(operation), "bitdepth", params->gifBitdepth, NULL);
+  }
   return ret;
 }
 
@@ -414,7 +422,11 @@ int save_to_buffer(SaveParams *params) {
     case TIFF:
       return save_buffer("tiffsave_buffer", params, set_tiffsave_options);
     case GIF:
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 12)
       return save_buffer("gifsave_buffer", params, set_gifsave_options);
+#else
+      return save_buffer("magicksave_buffer", params, set_magicksave_options);
+#endif
     case AVIF:
       return save_buffer("heifsave_buffer", params, set_avifsave_options);
     case JP2K:
@@ -467,6 +479,10 @@ static SaveParams defaultSaveParams = {
     .pngBitdepth = 0,
     .pngDither = 0,
     .pngFilter = VIPS_FOREIGN_PNG_FILTER_NONE,
+
+    .gifDither = 0.0,
+    .gifEffort = 0,
+    .gifBitdepth = 0,
 
     .webpLossless = FALSE,
     .webpNearLossless = FALSE,

--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -327,6 +327,14 @@ int set_magicksave_options(VipsOperation *operation, SaveParams *params) {
   return ret;
 }
 
+// https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-gifsave-buffer
+int set_gifsave_options(VipsOperation *operation, SaveParams *params) {
+  // TODO: Set optional arguments?
+  //  int ret = vips_object_set(VIPS_OBJECT(operation), "quality", params->quality, NULL);
+  int ret = 0;
+  return ret;
+}
+
 int set_avifsave_options(VipsOperation *operation, SaveParams *params) {
   int ret = vips_object_set(
       VIPS_OBJECT(operation), "compression", VIPS_FOREIGN_HEIF_COMPRESSION_AV1,
@@ -406,7 +414,7 @@ int save_to_buffer(SaveParams *params) {
     case TIFF:
       return save_buffer("tiffsave_buffer", params, set_tiffsave_options);
     case GIF:
-      return save_buffer("magicksave_buffer", params, set_magicksave_options);
+      return save_buffer("gifsave_buffer", params, set_gifsave_options);
     case AVIF:
       return save_buffer("heifsave_buffer", params, set_avifsave_options);
     case JP2K:

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -428,6 +428,9 @@ func vipsSaveGIFToBuffer(in *C.VipsImage, params GifExportParams) ([]byte, error
 	p := C.create_save_params(C.GIF)
 	p.inputImage = in
 	p.quality = C.int(params.Quality)
+	p.gifDither = C.double(params.Dither)
+	p.gifEffort = C.int(params.Effort)
+	p.gifBitdepth = C.int(params.Bitdepth)
 
 	return vipsSaveToBuffer(p)
 }

--- a/vips/foreign.h
+++ b/vips/foreign.h
@@ -96,6 +96,11 @@ typedef struct SaveParams {
   double pngDither;
   int pngBitdepth;
 
+  // GIF (with CGIF)
+  double gifDither;
+  int gifEffort;
+  int gifBitdepth;
+
   // WEBP
   BOOL webpLossless;
   BOOL webpNearLossless;

--- a/vips/image.go
+++ b/vips/image.go
@@ -321,12 +321,17 @@ func NewTiffExportParams() *TiffExportParams {
 type GifExportParams struct {
 	StripMetadata bool
 	Quality       int
+	Dither        float64
+	Effort        int
+	Bitdepth      int
 }
 
 // NewGifExportParams creates default values for an export of a GIF image.
 func NewGifExportParams() *GifExportParams {
 	return &GifExportParams{
-		Quality: 75,
+		Quality:  75,
+		Effort:   7,
+		Bitdepth: 8,
 	}
 }
 


### PR DESCRIPTION
I use libvips without magick and I would like to start generating gif files, which is possible since [libvips version 8.12.0](https://www.libvips.org/2021/11/14/What's-new-in-8.12.html). However `govips` still hardcodes the codepath to use `magicksave` for all gif exports. It results in the error `VipsOperation: class "magicksave_buffer" not found` (see https://github.com/davidbyttow/govips/issues/255 as well).

This PR does a version detection to check whether the libvips version `>= 8.12.0` and if true, defaults to using the new gifsave function which is much faster.

This is technically backwards incompatible (you need a new dependency [CGIF](https://github.com/dloebl/cgif), the ubuntu package name is `libcgif-dev`) otherwise the GIF saving feature is broken. I tried doing a runtime feature detection check for cgif, but couldn't find a way to make it work. However, currently trying to save gifs without having magick also results in an error, so I'm not sure how much of a problem this is.

Let me know if I need to tweak this PR further :).
