### PR TITLE
Update example_mozjepg_image.go to close image

### DIFF
--- a/examples/jpeg/example_mozjpeg_image.go
+++ b/examples/jpeg/example_mozjpeg_image.go
@@ -28,6 +28,7 @@ func ExampleMozJPEGEncode() {
 
 	inputImage, err := vips.NewImageFromFile("resources/jpg-24bit-icc-adobe-rgb.jpg")
 	checkError(err)
+	defer inputImage.Close()
 	checkError(inputImage.OptimizeICCProfile())
 
 	ep := vips.NewJpegExportParams()


### PR DESCRIPTION
close image after it is open in the example. Otherwise it could cause memory leak. 

This actually happened in my small server. A function was called multiple times to resize images, and  all the images were very large. The server got frozen due to memory explosive.