### PR TITLE
Add `PngExportParams.Filter` option to .png export

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -102,6 +102,20 @@ const (
 	TiffPredictorFloat      TiffPredictor = C.VIPS_FOREIGN_TIFF_PREDICTOR_FLOAT
 )
 
+// PngFilter represents filter algorithms that can be applied before compression.
+// See https://www.w3.org/TR/PNG-Filters.html
+type PngFilter int
+
+// PngFilter enum
+const (
+	PngFilterNone  PngFilter = C.VIPS_FOREIGN_PNG_FILTER_NONE
+	PngFilterSub   PngFilter = C.VIPS_FOREIGN_PNG_FILTER_SUB
+	PngFilterUo    PngFilter = C.VIPS_FOREIGN_PNG_FILTER_UP
+	PngFilterAvg   PngFilter = C.VIPS_FOREIGN_PNG_FILTER_AVG
+	PngFilterPaeth PngFilter = C.VIPS_FOREIGN_PNG_FILTER_PAETH
+	PngFilterAll   PngFilter = C.VIPS_FOREIGN_PNG_FILTER_ALL
+)
+
 // FileExt returns the canonical extension for the ImageType
 func (i ImageType) FileExt() string {
 	if ext, ok := imageTypeExtensionMap[i]; ok {
@@ -344,6 +358,7 @@ func vipsSavePNGToBuffer(in *C.VipsImage, params PngExportParams) ([]byte, error
 	p.stripMetadata = C.int(boolToInt(params.StripMetadata))
 	p.interlace = C.int(boolToInt(params.Interlace))
 	p.pngCompression = C.int(params.Compression)
+	p.pngFilter = C.VipsForeignPngFilter(params.Filter)
 	p.pngPalette = C.int(boolToInt(params.Palette))
 	p.pngDither = C.double(params.Dither)
 	p.pngBitdepth = C.int(params.Bitdepth)

--- a/vips/image.go
+++ b/vips/image.go
@@ -248,6 +248,7 @@ func NewJpegExportParams() *JpegExportParams {
 type PngExportParams struct {
 	StripMetadata bool
 	Compression   int
+	Filter        PngFilter
 	Interlace     bool
 	Quality       int
 	Palette       bool
@@ -261,6 +262,7 @@ type PngExportParams struct {
 func NewPngExportParams() *PngExportParams {
 	return &PngExportParams{
 		Compression: 6,
+		Filter:      PngFilterNone,
 		Interlace:   false,
 		Palette:     false,
 	}


### PR DESCRIPTION
I want to implement something like `optipng`: try compress .png with differ filter and get smallest image.

More info about the PNG delta filters can be found at http://optipng.sourceforge.net/pngtech/optipng.html on section 2.2.