### PR TITLE
implement vips_image_new_from_file

### DIFF
--- a/vips/header.go
+++ b/vips/header.go
@@ -126,6 +126,9 @@ func vipsImageSetDelay(in *C.VipsImage, data []C.int) error {
 
 // vipsDetermineImageTypeFromMetaLoader determine the image type from vips-loader metadata
 func vipsDetermineImageTypeFromMetaLoader(in *C.VipsImage) ImageType {
+	if in == nil {
+		return ImageTypeUnknown
+	}
 	vipsLoader, ok := vipsImageGetMetaLoader(in)
 	if vipsLoader == "" || !ok {
 		return ImageTypeUnknown

--- a/vips/image.c
+++ b/vips/image.c
@@ -6,3 +6,16 @@ void clear_image(VipsImage **image) {
   // https://developer.gnome.org/gobject/stable/gobject-The-Base-Object-Type.html#g-clear-object
   if (G_IS_OBJECT(*image)) g_clear_object(image);
 }
+
+int image_new_from_buffer(const void *buf, size_t len, VipsImage **out, const char *option_string) {
+  *out = vips_image_new_from_buffer(buf, len, option_string, NULL);
+  if (!out) return 1;
+  return 0;
+}
+
+int image_new_from_file(const char *name, VipsImage **out) {
+  *out = vips_image_new_from_file(name, NULL);
+  if (!out) return 1;
+  return 0;
+}
+

--- a/vips/image.c
+++ b/vips/image.c
@@ -9,13 +9,13 @@ void clear_image(VipsImage **image) {
 
 int image_new_from_buffer(const void *buf, size_t len, VipsImage **out, const char *option_string) {
   *out = vips_image_new_from_buffer(buf, len, option_string, NULL);
-  if (!out) return 1;
+  if (!*out) return 1;
   return 0;
 }
 
 int image_new_from_file(const char *name, VipsImage **out) {
   *out = vips_image_new_from_file(name, NULL);
-  if (!out) return 1;
+  if (!*out) return 1;
   return 0;
 }
 

--- a/vips/image.go
+++ b/vips/image.go
@@ -1799,7 +1799,7 @@ func vipsImageFromFile(filename string, params *ImportParams) (*C.VipsImage, Ima
 	cFileName := C.CString(filenameOption)
 	defer freeCString(cFileName)
 
-	if err := C.image_new_from_file(cFileName, &out); err != 0 {
+	if code := C.image_new_from_file(cFileName, &out); code != 0 {
 		err := handleImageError(out)
 		if src, err2 := ioutil.ReadFile(filename); err2 == nil {
 			if isBMP(src) {

--- a/vips/image.go
+++ b/vips/image.go
@@ -390,13 +390,16 @@ func NewImageFromFile(file string) (*ImageRef, error) {
 
 // LoadImageFromFile loads an image from file and creates a new ImageRef
 func LoadImageFromFile(file string, params *ImportParams) (*ImageRef, error) {
-	buf, err := ioutil.ReadFile(file)
+	startupIfNeeded()
+
+	vipsImage, format, err := vipsImageFromFile(file, params)
 	if err != nil {
 		return nil, err
 	}
 
+	ref := newImageRef(vipsImage, format, nil)
 	govipsLog("govips", LogLevelDebug, fmt.Sprintf("creating imageRef from file %s", file))
-	return LoadImageFromBuffer(buf, params)
+	return ref, nil
 }
 
 // NewImageFromBuffer loads an image buffer and creates a new Image

--- a/vips/image.go
+++ b/vips/image.go
@@ -1792,10 +1792,14 @@ func (r *ImageRef) setImage(image *C.VipsImage) {
 // https://www.libvips.org/API/current/VipsImage.html#vips-image-new-from-file
 func vipsImageFromFile(filename string, params *ImportParams) (*C.VipsImage, ImageType, error) {
 	var out *C.VipsImage
-	cName := C.CString(filename + params.OptionString())
-	defer freeCString(cName)
+	imageParams := filename
+	if params != nil {
+		imageParams += params.OptionString()
+	}
+	cImageParams := C.CString(imageParams)
+	defer freeCString(cImageParams)
 
-	if err := C.image_new_from_file(cName, &out); err != 0 {
+	if err := C.image_new_from_file(cImageParams, &out); err != 0 {
 		err := handleImageError(out)
 		if src, err2 := ioutil.ReadFile(filename); err2 == nil {
 			if isBMP(src) {

--- a/vips/image.go
+++ b/vips/image.go
@@ -1792,14 +1792,14 @@ func (r *ImageRef) setImage(image *C.VipsImage) {
 // https://www.libvips.org/API/current/VipsImage.html#vips-image-new-from-file
 func vipsImageFromFile(filename string, params *ImportParams) (*C.VipsImage, ImageType, error) {
 	var out *C.VipsImage
-	imageParams := filename
+	filenameOption := filename
 	if params != nil {
-		imageParams += params.OptionString()
+		filenameOption += "[" + params.OptionString() + "]"
 	}
-	cImageParams := C.CString(imageParams)
-	defer freeCString(cImageParams)
+	cFileName := C.CString(filenameOption)
+	defer freeCString(cFileName)
 
-	if err := C.image_new_from_file(cImageParams, &out); err != 0 {
+	if err := C.image_new_from_file(cFileName, &out); err != 0 {
 		err := handleImageError(out)
 		if src, err2 := ioutil.ReadFile(filename); err2 == nil {
 			if isBMP(src) {

--- a/vips/image.go
+++ b/vips/image.go
@@ -1789,6 +1789,28 @@ func (r *ImageRef) setImage(image *C.VipsImage) {
 	r.image = image
 }
 
+// https://www.libvips.org/API/current/VipsImage.html#vips-image-new-from-file
+func vipsImageFromFile(filename string, params *ImportParams) (*C.VipsImage, ImageType, error) {
+	var out *C.VipsImage
+	cName := C.CString(filename + params.OptionString())
+	defer freeCString(cName)
+
+	if err := C.image_new_from_file(cName, &out); err != 0 {
+		err := handleImageError(out)
+		if src, err2 := ioutil.ReadFile(filename); err2 == nil {
+			if isBMP(src) {
+				if src2, err3 := bmpToPNG(src); err3 == nil {
+					return vipsLoadFromBuffer(src2, params)
+				}
+			}
+		}
+		return nil, ImageTypeUnknown, err
+	}
+
+	imageType := vipsDetermineImageTypeFromMetaLoader(out)
+	return out, imageType, nil
+}
+
 func vipsHasAlpha(in *C.VipsImage) bool {
 	return int(C.has_alpha_channel(in)) > 0
 }

--- a/vips/image.h
+++ b/vips/image.h
@@ -6,3 +6,8 @@
 int has_alpha_channel(VipsImage *image);
 
 void clear_image(VipsImage **image);
+
+int image_new_from_buffer(const void *buf, size_t len, VipsImage **out, const char *option_string);
+
+int image_new_from_file(const char *name, VipsImage **out);
+

--- a/vips/image_golden_test.go
+++ b/vips/image_golden_test.go
@@ -903,6 +903,24 @@ func goldenTest(
 
 	assertGoldenMatch(t, path, buf, metadata.Format)
 
+	buf2, err := ioutil.ReadFile(path)
+	require.NoError(t, err)
+
+	img2, err := NewImageFromBuffer(buf2)
+
+	err = exec(img2)
+	require.NoError(t, err)
+
+	buf2, metadata2, err := export(img2)
+	require.NoError(t, err)
+
+	result2, err := NewImageFromBuffer(buf2)
+	require.NoError(t, err)
+
+	validate(result2)
+
+	assertGoldenMatch(t, path, buf2, metadata2.Format)
+
 	return buf
 }
 

--- a/vips/resample.go
+++ b/vips/resample.go
@@ -121,28 +121,6 @@ func vipsThumbnailFromBuffer(buf []byte, width, height int, crop Interesting, si
 	return out, imageType, nil
 }
 
-// https://www.libvips.org/API/current/VipsImage.html#vips-image-new-from-file
-func vipsImageFromFile(filename string, params *ImportParams) (*C.VipsImage, ImageType, error) {
-	var out *C.VipsImage
-	cName := C.CString(filename + params.OptionString())
-	defer freeCString(cName)
-
-	if err := C.image_new_from_file(cName, &out); err != 0 {
-		err := handleImageError(out)
-		if src, err2 := ioutil.ReadFile(filename); err2 == nil {
-			if isBMP(src) {
-				if src2, err3 := bmpToPNG(src); err3 == nil {
-					return vipsLoadFromBuffer(src2, params)
-				}
-			}
-		}
-		return nil, ImageTypeUnknown, err
-	}
-
-	imageType := vipsDetermineImageTypeFromMetaLoader(out)
-	return out, imageType, nil
-}
-
 // https://libvips.github.io/libvips/API/current/libvips-resample.html#vips-mapim
 func vipsMapim(in *C.VipsImage, index *C.VipsImage) (*C.VipsImage, error) {
 	incOpCounter("mapim")

--- a/vips/resample.go
+++ b/vips/resample.go
@@ -121,6 +121,28 @@ func vipsThumbnailFromBuffer(buf []byte, width, height int, crop Interesting, si
 	return out, imageType, nil
 }
 
+// https://www.libvips.org/API/current/VipsImage.html#vips-image-new-from-file
+func vipsImageFromFile(filename string, params *ImportParams) (*C.VipsImage, ImageType, error) {
+	var out *C.VipsImage
+	cName := C.CString(filename + params.OptionString())
+	defer freeCString(cName)
+
+	if err := C.image_new_from_file(cName, &out); err != 0 {
+		err := handleImageError(out)
+		if src, err2 := ioutil.ReadFile(filename); err2 == nil {
+			if isBMP(src) {
+				if src2, err3 := bmpToPNG(src); err3 == nil {
+					return vipsLoadFromBuffer(src2, params)
+				}
+			}
+		}
+		return nil, ImageTypeUnknown, err
+	}
+
+	imageType := vipsDetermineImageTypeFromMetaLoader(out)
+	return out, imageType, nil
+}
+
 // https://libvips.github.io/libvips/API/current/libvips-resample.html#vips-mapim
 func vipsMapim(in *C.VipsImage, index *C.VipsImage) (*C.VipsImage, error) {
 	incOpCounter("mapim")


### PR DESCRIPTION
This enables creating new image object directly from file path, using [vips_image_new_from_file](https://www.libvips.org/API/current/VipsImage.html#vips-image-new-from-file):

Below is the go bench of `NewImageFromFile` against the master branch. The memory difference `B/op` is very noticeable. The speed maybe slightly slower, presumably due to disk seek (instead of all loaded in memory).

```bash
(base) ➜  govips git:(master) go test -bench=NewImageFromFile -benchtime=30s -benchmem ./examples/thumbnail
goos: darwin
goarch: amd64
pkg: github.com/davidbyttow/govips/v2/examples/thumbnail
cpu: Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
BenchmarkNewImageFromFile-4           91         388221588 ns/op         2600845 B/op        234 allocs/op
PASS
ok      github.com/davidbyttow/govips/v2/examples/thumbnail     36.420s

(base) ➜  govips git:(vips_new_image) go test -bench=NewImageFromFile -benchtime=30s -benchmem ./examples/thumbnail
goos: darwin
goarch: amd64
pkg: github.com/davidbyttow/govips/v2/examples/thumbnail
cpu: Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
BenchmarkNewImageFromFile-4           90         395057470 ns/op          261382 B/op        201 allocs/op
PASS
ok      github.com/davidbyttow/govips/v2/examples/thumbnail     36.167s
```

However this relies on libvips's [VIPS_META_LOADER](https://www.libvips.org/API/current/libvips-header.html#VIPS-META-LOADER:CAPS) to determine image type, instead of govips's `DetermineImageType`, which potentially introduces different behaviour for edge cases.

Tests passing under Linux, but `TestImage_DrawRectRGBA` seems to be failing under MacOS I am not sure why.

#289 