### PR TITLE
Fix ImageType for AVIF

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -73,7 +73,7 @@ var ImageTypes = map[ImageType]string{
 	ImageTypeWEBP:   "webp",
 	ImageTypeHEIF:   "heif",
 	ImageTypeBMP:    "bmp",
-	ImageTypeAVIF:   "heif",
+	ImageTypeAVIF:   "avif",
 	ImageTypeJP2K:   "jp2k",
 }
 


### PR DESCRIPTION
The `ImageTypeAVIF` was set to `"heif"`, but should be `"avif"`.
Looks like a copy/paste error, introduced with https://github.com/davidbyttow/govips/pull/190