### PR TITLE
Remove implicit bitmap to png conversions

### DIFF
--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -132,22 +132,6 @@ func TestImageRef_HEIF_ftypmsf1(t *testing.T) {
 	assert.Equal(t, ImageTypeHEIF, metadata.Format)
 }
 
-func TestImageRef_BMP__ImplicitConversionToPNG(t *testing.T) {
-	Startup(nil)
-
-	raw, err := ioutil.ReadFile(resources + "bmp.bmp")
-	require.NoError(t, err)
-
-	img, err := NewImageFromBuffer(raw)
-	require.NoError(t, err)
-	require.NotNil(t, img)
-
-	exported, metadata, err := img.ExportNative()
-	assert.NoError(t, err)
-	assert.Equal(t, ImageTypePNG, metadata.Format)
-	assert.NotNil(t, exported)
-}
-
 func TestImageRef_SVG(t *testing.T) {
 	Startup(nil)
 

--- a/vips/resample.go
+++ b/vips/resample.go
@@ -3,7 +3,6 @@ package vips
 // #include "resample.h"
 import "C"
 import (
-	"io/ioutil"
 	"runtime"
 	"unsafe"
 )
@@ -75,13 +74,7 @@ func vipsThumbnailFromFile(filename string, width, height int, crop Interesting,
 
 	if err := C.thumbnail(cFileName, &out, C.int(width), C.int(height), C.int(crop), C.int(size)); err != 0 {
 		err := handleImageError(out)
-		if src, err2 := ioutil.ReadFile(filename); err2 == nil {
-			if isBMP(src) {
-				if src2, err3 := bmpToPNG(src); err3 == nil {
-					return vipsThumbnailFromBuffer(src2, width, height, crop, size, params)
-				}
-			}
-		}
+
 		return nil, ImageTypeUnknown, err
 	}
 
@@ -109,11 +102,6 @@ func vipsThumbnailFromBuffer(buf []byte, width, height int, crop Interesting, si
 	}
 	if err != 0 {
 		err := handleImageError(out)
-		if isBMP(src) {
-			if src2, err2 := bmpToPNG(src); err2 == nil {
-				return vipsThumbnailFromBuffer(src2, width, height, crop, size, params)
-			}
-		}
 		return nil, ImageTypeUnknown, err
 	}
 


### PR DESCRIPTION
The bitmap library used for this does not support the various bitmap
formats in the wild. This is also very confusing behaviour for a user of
the pre-v2 version of govips, which was able to handle all the various
bmp files

Closes #300

I can't run the test suite on my local machine, so I'm pushing here to see if the tests run successfully