### PR TITLE
Add APIs to get image EXIF data and ICC profile data

### DIFF
--- a/vips/header.c
+++ b/vips/header.c
@@ -6,6 +6,19 @@ unsigned long has_icc_profile(VipsImage *in) {
   return vips_image_get_typeof(in, VIPS_META_ICC_NAME);
 }
 
+unsigned long get_icc_profile(VipsImage *in, const void **data,
+                              size_t *dataLength) {
+  if (vips_image_get_typeof(in, VIPS_META_ICC_NAME) == 0) {
+    return 0;
+  }
+
+  if (vips_image_get_blob(in, VIPS_META_ICC_NAME, data, dataLength)) {
+    return -1;
+  }
+
+  return 0;
+}
+
 gboolean remove_icc_profile(VipsImage *in) {
   return vips_image_remove(in, VIPS_META_ICC_NAME);
 }
@@ -14,13 +27,14 @@ unsigned long has_iptc(VipsImage *in) {
   return vips_image_get_typeof(in, VIPS_META_IPTC_NAME);
 }
 
-char** image_get_fields(VipsImage *in) {
-  return vips_image_get_fields(in);
+char **image_get_fields(VipsImage *in) { return vips_image_get_fields(in); }
+
+unsigned long image_get_string(VipsImage *in, const char *name,
+                               const char **out) {
+  return vips_image_get_string(in, name, out);
 }
 
-void remove_field(VipsImage *in, char *field) {
-  vips_image_remove(in, field);
-}
+void remove_field(VipsImage *in, char *field) { vips_image_remove(in, field); }
 
 int get_meta_orientation(VipsImage *in) {
   int orientation = 0;

--- a/vips/header.h
+++ b/vips/header.h
@@ -4,10 +4,14 @@
 #include <vips/vips.h>
 
 unsigned long has_icc_profile(VipsImage *in);
+unsigned long get_icc_profile(VipsImage *in, const void **data,
+                              size_t *dataLength);
 int remove_icc_profile(VipsImage *in);
 
 unsigned long has_iptc(VipsImage *in);
-char** image_get_fields(VipsImage *in);
+char **image_get_fields(VipsImage *in);
+unsigned long image_get_string(VipsImage *in, const char *name,
+                               const char **out);
 void remove_field(VipsImage *in, char *field);
 
 int get_meta_orientation(VipsImage *in);

--- a/vips/image.go
+++ b/vips/image.go
@@ -1252,6 +1252,12 @@ func (r *ImageRef) ExtractArea(left, top, width, height int) error {
 	return nil
 }
 
+// GetICCProfile retrieves the ICC profile data (if any) from the image.
+func (r *ImageRef) GetICCProfile() []byte {
+	bytes, _ := vipsGetICCProfile(r.image)
+	return bytes
+}
+
 // RemoveICCProfile removes the ICC Profile information from the image.
 // Typically, browsers and other software assume images without profile to be in the sRGB color space.
 func (r *ImageRef) RemoveICCProfile() error {
@@ -1345,6 +1351,10 @@ func (r *ImageRef) HasExif() bool {
 	return false
 }
 
+func (r *ImageRef) GetExif() map[string]string {
+	return vipsImageGetExifData(r.image)
+}
+
 // ToColorSpace changes the color space of the image to the interpretation supplied as the parameter.
 func (r *ImageRef) ToColorSpace(interpretation Interpretation) error {
 	out, err := vipsToColorSpace(r.image, interpretation)
@@ -1369,8 +1379,8 @@ func (r *ImageRef) Flatten(backgroundColor *Color) error {
 // add support minAmpl
 func (r *ImageRef) GaussianBlur(sigmas ...float64) error {
 	var (
-		sigma  = sigmas[0]
-		minAmpl  = GaussBlurDefaultMinAMpl
+		sigma   = sigmas[0]
+		minAmpl = GaussBlurDefaultMinAMpl
 	)
 	if len(sigmas) >= 2 {
 		minAmpl = sigmas[1]
@@ -1819,6 +1829,7 @@ func clearImage(ref *C.VipsImage) {
 type Coding int
 
 // Coding enum
+//
 //goland:noinspection GoUnusedConst
 const (
 	CodingError Coding = C.VIPS_CODING_ERROR

--- a/vips/image_golden_test.go
+++ b/vips/image_golden_test.go
@@ -109,6 +109,8 @@ func TestImage_TransformICCProfile_RGB_No_Profile(t *testing.T) {
 		},
 		func(result *ImageRef) {
 			assert.True(t, result.HasICCProfile())
+			iccProfileData := result.GetICCProfile()
+			assert.Greater(t, len(iccProfileData), 0)
 			assert.Equal(t, InterpretationSRGB, result.Interpretation())
 		}, nil)
 }
@@ -191,6 +193,8 @@ func TestImage_RemoveMetadata_Removes_Exif(t *testing.T) {
 	goldenTest(t, resources+"heic-24bit-exif.heic",
 		func(img *ImageRef) error {
 			assert.True(t, img.HasExif())
+			exifData := img.GetExif()
+			assert.Greater(t, len(exifData), 0)
 			return img.RemoveMetadata()
 		},
 		func(img *ImageRef) {
@@ -491,7 +495,7 @@ func TestImage_GaussianBlur(t *testing.T) {
 		return img.GaussianBlur(10.5)
 	}, nil, nil)
 	goldenTest(t, resources+"jpg-24bit.jpg", func(img *ImageRef) error {
-		return img.GaussianBlur(10.5,0.2)
+		return img.GaussianBlur(10.5, 0.2)
 	}, nil, nil)
 }
 
@@ -740,7 +744,7 @@ func TestImage_Black(t *testing.T) {
 	assertGoldenMatch(t, resources+"jpg-24bit.jpg", buf, metadata.Format)
 }
 
-//vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --subsample-mode=auto --interlace --optimize-coding
+// vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --subsample-mode=auto --interlace --optimize-coding
 func TestImage_OptimizeCoding(t *testing.T) {
 	goldenTest(t, resources+"jpg-24bit-icc-iec.jpg",
 		nil,
@@ -755,7 +759,7 @@ func TestImage_OptimizeCoding(t *testing.T) {
 	)
 }
 
-//vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --subsample-mode=on
+// vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --subsample-mode=on
 func TestImage_SubsampleMode(t *testing.T) {
 	goldenTest(t, resources+"jpg-24bit-icc-iec.jpg",
 		nil,
@@ -768,7 +772,7 @@ func TestImage_SubsampleMode(t *testing.T) {
 	)
 }
 
-//vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --trellis-quant
+// vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --trellis-quant
 func TestImage_TrellisQuant(t *testing.T) {
 	goldenTest(t, resources+"jpg-24bit-icc-iec.jpg",
 		nil,
@@ -782,7 +786,7 @@ func TestImage_TrellisQuant(t *testing.T) {
 	)
 }
 
-//vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --overshoot-deringing
+// vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --overshoot-deringing
 func TestImage_OvershootDeringing(t *testing.T) {
 	goldenTest(t, resources+"jpg-24bit-icc-iec.jpg",
 		nil,
@@ -796,7 +800,7 @@ func TestImage_OvershootDeringing(t *testing.T) {
 	)
 }
 
-//vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --interlace --optimize-scans
+// vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --interlace --optimize-scans
 func TestImage_OptimizeScans(t *testing.T) {
 	goldenTest(t, resources+"jpg-24bit-icc-iec.jpg",
 		nil,
@@ -811,7 +815,7 @@ func TestImage_OptimizeScans(t *testing.T) {
 	)
 }
 
-//vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --quant-table=3
+// vips jpegsave resources/jpg-24bit-icc-iec.jpg test.jpg --Q=75 --profile=none --strip --quant-table=3
 func TestImage_QuantTable(t *testing.T) {
 	goldenTest(t, resources+"jpg-24bit-icc-iec.jpg",
 		nil,


### PR DESCRIPTION
These are two APIs I've wanted for a while and I finally got around to implementing them + making a pull request.

The first, GetICCProfile, is related to HasICCProfile but it actually returns the byte slice resulting from invoking vips_image_get_blob with the VIPS_META_ICC_NAME parameter. 

This is useful for me as well as hopefully other consumers because I want to parse the data with LCMS2 and determine the ICC profile name and whether it's a wide color profile or not.

The second API, GetExif, is related to ImageFields but it actually returns the string values in a map for all of the image fields with an "exif" prefix.

This is useful for pulling interesting information out of images like the type of camera and lens.