### PR TITLE
support fail_on level

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -26,8 +26,8 @@ int load_image_buffer(LoadParams *params, void *buf, size_t len,
   ImageType imageType = params->inputFormat;
 
   if (imageType == JPEG) {
-    // shrink: int, fail: bool, autorotate: bool
-    code = vips_jpegload_buffer(buf, len, out, "fail", params->fail,
+    // shrink: int, fail_on: int, autorotate: bool
+    code = vips_jpegload_buffer(buf, len, out, "fail_on", params->failOn,
                                 "autorotate", params->autorotate, "shrink",
                                 params->jpegShrink, NULL);
   } else if (imageType == PNG) {
@@ -98,13 +98,13 @@ typedef int (*SetLoadOptionsFn)(VipsOperation *operation, LoadParams *params);
 
 int set_jpegload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_BOOL(operation, params->autorotate, "autorotate");
-  MAYBE_SET_BOOL(operation, params->fail, "fail");
+  MAYBE_SET_INT(operation, params->failOn, "fail_on");
   MAYBE_SET_INT(operation, params->jpegShrink, "shrink");
   return 0;
 }
 
 int set_pngload_options(VipsOperation *operation, LoadParams *params) {
-  MAYBE_SET_BOOL(operation, params->fail, "fail");
+  MAYBE_SET_INT(operation, params->failOn, "fail_on");
   return 0;
 }
 
@@ -449,7 +449,7 @@ LoadParams create_load_params(ImageType inputFormat) {
       .inputBlob = NULL,
       .outputImage = NULL,
       .autorotate = defaultParam,
-      .fail = defaultParam,
+      .failOn = defaultParam,
       .page = defaultParam,
       .n = defaultParam,
       .dpi = defaultParam,

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -116,6 +116,31 @@ const (
 	PngFilterAll   PngFilter = C.VIPS_FOREIGN_PNG_FILTER_ALL
 )
 
+// FailOnLevel fail_on level
+type FailOnLevel int
+
+const (
+	FailOnNone      FailOnLevel = C.VIPS_FAIL_ON_NONE
+	FailOnTruncated FailOnLevel = C.VIPS_FAIL_ON_TRUNCATED
+	FailOnError     FailOnLevel = C.VIPS_FAIL_ON_ERROR
+	FailOnWarning   FailOnLevel = C.VIPS_FAIL_ON_WARNING
+)
+
+func (f FailOnLevel) String() string {
+	switch f {
+	case FailOnNone:
+		return "none"
+	case FailOnTruncated:
+		return "truncated"
+	case FailOnError:
+		return "error"
+	case FailOnWarning:
+		return "warning"
+	default:
+		return "error"
+	}
+}
+
 // FileExt returns the canonical extension for the ImageType
 func (i ImageType) FileExt() string {
 	if ext, ok := imageTypeExtensionMap[i]; ok {
@@ -319,7 +344,7 @@ func createImportParams(format ImageType, params *ImportParams) C.LoadParams {
 	p := C.create_load_params(C.ImageType(format))
 
 	maybeSetBoolParam(params.AutoRotate, &p.autorotate)
-	maybeSetBoolParam(params.FailOnError, &p.fail)
+	maybeSetIntParam(params.FailOnError, &p.failOn)
 	maybeSetIntParam(params.Page, &p.page)
 	maybeSetIntParam(params.NumPages, &p.n)
 	maybeSetIntParam(params.JpegShrinkFactor, &p.jpegShrink)

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -120,26 +120,11 @@ const (
 type FailOnLevel int
 
 const (
-	FailOnNone      FailOnLevel = C.VIPS_FAIL_ON_NONE
-	FailOnTruncated FailOnLevel = C.VIPS_FAIL_ON_TRUNCATED
-	FailOnError     FailOnLevel = C.VIPS_FAIL_ON_ERROR
-	FailOnWarning   FailOnLevel = C.VIPS_FAIL_ON_WARNING
+	FailOnNone      FailOnLevel = 0 //C.VIPS_FAIL_ON_NONE
+	FailOnTruncated FailOnLevel = 1 //C.VIPS_FAIL_ON_TRUNCATED
+	FailOnError     FailOnLevel = 2 //C.VIPS_FAIL_ON_ERROR
+	FailOnWarning   FailOnLevel = 3 //C.VIPS_FAIL_ON_WARNING
 )
-
-func (f FailOnLevel) String() string {
-	switch f {
-	case FailOnNone:
-		return "none"
-	case FailOnTruncated:
-		return "truncated"
-	case FailOnError:
-		return "error"
-	case FailOnWarning:
-		return "warning"
-	default:
-		return "error"
-	}
-}
 
 // FileExt returns the canonical extension for the ImageType
 func (i ImageType) FileExt() string {
@@ -344,7 +329,7 @@ func createImportParams(format ImageType, params *ImportParams) C.LoadParams {
 	p := C.create_load_params(C.ImageType(format))
 
 	maybeSetBoolParam(params.AutoRotate, &p.autorotate)
-	maybeSetIntParam(params.FailOnError, &p.failOn)
+	maybeSetIntParam(params.FailOn, &p.failOn)
 	maybeSetIntParam(params.Page, &p.page)
 	maybeSetIntParam(params.NumPages, &p.n)
 	maybeSetIntParam(params.JpegShrinkFactor, &p.jpegShrink)

--- a/vips/foreign.h
+++ b/vips/foreign.h
@@ -58,7 +58,7 @@ typedef struct LoadParams {
   VipsImage *outputImage;
 
   Param autorotate;
-  Param fail;
+  Param failOn;
   Param page;
   Param n;
   Param dpi;

--- a/vips/image.go
+++ b/vips/image.go
@@ -102,7 +102,7 @@ func (p *Float64Parameter) Get() float64 {
 // For default loading, use NewImportParams() or specify nil
 type ImportParams struct {
 	AutoRotate  BoolParameter
-	FailOnError BoolParameter
+	FailOnError IntParameter
 	Page        IntParameter
 	NumPages    IntParameter
 	Density     IntParameter
@@ -115,7 +115,9 @@ type ImportParams struct {
 // NewImportParams creates default ImportParams
 func NewImportParams() *ImportParams {
 	p := &ImportParams{}
-	p.FailOnError.Set(true)
+	if !p.FailOnError.IsSet(){
+		p.FailOnError.Set(int(FailOnError))
+	}
 	return p
 }
 
@@ -132,7 +134,7 @@ func (i *ImportParams) OptionString() string {
 		values = append(values, "dpi="+strconv.Itoa(v.Get()))
 	}
 	if v := i.FailOnError; v.IsSet() {
-		values = append(values, "fail="+boolToStr(v.Get()))
+		values = append(values, "fail_on="+FailOnLevel(v.Get()).String())
 	}
 	if v := i.JpegShrinkFactor; v.IsSet() {
 		values = append(values, "shrink="+strconv.Itoa(v.Get()))

--- a/vips/image.go
+++ b/vips/image.go
@@ -101,11 +101,11 @@ func (p *Float64Parameter) Get() float64 {
 // ImportParams are options for loading an image. Some are type-specific.
 // For default loading, use NewImportParams() or specify nil
 type ImportParams struct {
-	AutoRotate  BoolParameter
-	FailOnError IntParameter
-	Page        IntParameter
-	NumPages    IntParameter
-	Density     IntParameter
+	AutoRotate BoolParameter
+	FailOn     IntParameter
+	Page       IntParameter
+	NumPages   IntParameter
+	Density    IntParameter
 
 	JpegShrinkFactor IntParameter
 	HeifThumbnail    BoolParameter
@@ -115,8 +115,8 @@ type ImportParams struct {
 // NewImportParams creates default ImportParams
 func NewImportParams() *ImportParams {
 	p := &ImportParams{}
-	if !p.FailOnError.IsSet(){
-		p.FailOnError.Set(int(FailOnError))
+	if !p.FailOn.IsSet() {
+		p.FailOn.Set(int(FailOnError))
 	}
 	return p
 }
@@ -132,9 +132,6 @@ func (i *ImportParams) OptionString() string {
 	}
 	if v := i.Density; v.IsSet() {
 		values = append(values, "dpi="+strconv.Itoa(v.Get()))
-	}
-	if v := i.FailOnError; v.IsSet() {
-		values = append(values, "fail_on="+FailOnLevel(v.Get()).String())
 	}
 	if v := i.JpegShrinkFactor; v.IsSet() {
 		values = append(values, "shrink="+strconv.Itoa(v.Get()))


### PR DESCRIPTION
libvips support a variety of fail levels by fail_on.
This can fix  [issue](https://github.com/davidbyttow/govips/issues/319).