### PR TITLE
Fix bug with icc transform bit depth

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -1279,7 +1279,12 @@ func (r *ImageRef) TransformICCProfile(outputProfilePath string) error {
 	embedded := r.HasICCProfile()
 	inputProfile := SRGBIEC6196621ICCProfilePath
 
-	out, err := vipsICCTransform(r.image, outputProfilePath, inputProfile, IntentPerceptual, 0, embedded)
+	depth := 16
+	if r.BandFormat() == BandFormatUchar || r.BandFormat() == BandFormatChar || r.BandFormat() == BandFormatNotSet {
+		depth = 8
+	}
+
+	out, err := vipsICCTransform(r.image, outputProfilePath, inputProfile, IntentPerceptual, depth, embedded)
 	if err != nil {
 		govipsLog("govips", LogLevelError, fmt.Sprintf("failed to do icc transform: %v", err.Error()))
 		return err


### PR DESCRIPTION
This PR fixes a bug with the TransformICCProfile API. Here I was passing 0 for the bit depth (leaving it unset) but the default value if you do this is 8-bit. This causes ICC transforms of >8-bit images to revert to 8-bit and become distorted. The code I'm adding here was copied from the adjacent OptimizeICCProfile method which defaults to 16-bit processing unless the source image was already 8-bit.