### PR TITLE
BandSplit() split an n-band image into n separate images

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -1084,6 +1084,19 @@ func (r *ImageRef) BandJoin(images ...*ImageRef) error {
 	return nil
 }
 
+// BandSplit split an n-band image into n separate images..
+func (r *ImageRef) BandSplit() ([]*ImageRef, error) {
+	var out []*ImageRef
+	for i := 0; i < r.Bands(); i++ {
+		img, err := vipsExtractBand(r.image, i, 1)
+		if err != nil {
+			return out, err
+		}
+		out = append(out, &ImageRef{image: img})
+	}
+	return out, nil
+}
+
 // BandJoinConst appends a set of constant bands to an image.
 func (r *ImageRef) BandJoinConst(constants []float64) error {
 	out, err := vipsBandJoinConst(r.image, constants)

--- a/vips/image_golden_test.go
+++ b/vips/image_golden_test.go
@@ -745,21 +745,6 @@ func TestImage_ExtractBand(t *testing.T) {
 	}, nil, nil)
 }
 
-func TestImage_ExtractBandToImage(t *testing.T) {
-	goldenTest(t, resources+"with_alpha.png", func(img *ImageRef) error {
-		_, err := img.ExtractBandToImage(2, 1)
-		return err
-	}, nil, nil)
-}
-
-func TestImage_BandSplit(t *testing.T) {
-	goldenTest(t, resources+"with_alpha.png", func(img *ImageRef) error {
-		bands, err := img.BandSplit()
-		require.Len(t, bands, 4)
-		return err
-	}, nil, nil)
-}
-
 func TestImage_Flatten(t *testing.T) {
 	goldenTest(t, resources+"with_alpha.png", func(img *ImageRef) error {
 		return img.Flatten(&Color{R: 32, G: 64, B: 128})

--- a/vips/image_golden_test.go
+++ b/vips/image_golden_test.go
@@ -752,6 +752,14 @@ func TestImage_ExtractBandToImage(t *testing.T) {
 	}, nil, nil)
 }
 
+func TestImage_BandSplit(t *testing.T) {
+	goldenTest(t, resources+"with_alpha.png", func(img *ImageRef) error {
+		bands, err := img.BandSplit()
+		require.Len(t, bands, 4)
+		return err
+	}, nil, nil)
+}
+
 func TestImage_Flatten(t *testing.T) {
 	goldenTest(t, resources+"with_alpha.png", func(img *ImageRef) error {
 		return img.Flatten(&Color{R: 32, G: 64, B: 128})

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -813,6 +813,19 @@ func TestBandJoin(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestExtractBandToImage(t *testing.T) {
+	Startup(nil)
+	image1, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+
+	v, err := image1.ExtractBandToImage(0, 2)
+	require.NoError(t, err)
+	require.Equal(t, v.Bands(), 2)
+
+	_, err = v.ExtractBandToImage(0, 3)
+	require.Error(t, err)
+}
+
 func TestBandSplit(t *testing.T) {
 	Startup(nil)
 

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -813,6 +813,26 @@ func TestBandJoin(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestBandSplit(t *testing.T) {
+	Startup(nil)
+
+	image1, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+
+	bands, err := image1.BandSplit()
+	require.NoError(t, err)
+
+	require.Len(t, bands, 3)
+
+	image2, err := NewImageFromFile(resources + "with_alpha.png")
+	require.NoError(t, err)
+
+	bands2, err := image2.BandSplit()
+	require.NoError(t, err)
+
+	require.Len(t, bands2, 4)
+}
+
 func TestIsColorSpaceSupport(t *testing.T) {
 	Startup(nil)
 


### PR DESCRIPTION
provide quick function to split an image into n-bands

also move test from my previous PR into unit test instead of a golden test