### PR TITLE
Add TempDir config option

### DIFF
--- a/vips/govips.go
+++ b/vips/govips.go
@@ -52,6 +52,10 @@ type Config struct {
 	ReportLeaks      bool
 	CacheTrace       bool
 	CollectStats     bool
+
+	// TempDir is a directory to use while GoVips is running. If not specified,
+	// a tempdir in /tmp will be created.
+	TempDir string
 }
 
 // Startup sets up the libvips support and ensures the versions are correct. Pass in nil for
@@ -96,7 +100,11 @@ func Startup(config *Config) {
 		panic(fmt.Sprintf("Failed to start vips code=%v", err))
 	}
 
-	initializeICCProfiles()
+	if config != nil {
+		initializeICCProfiles(config.TempDir)
+	} else {
+		initializeICCProfiles("")
+	}
 
 	running = true
 

--- a/vips/icc_profiles.go
+++ b/vips/icc_profiles.go
@@ -644,14 +644,25 @@ var (
 		0x00, 0x20, 0x63, 0xcf, 0x8f, 0xf0, 0x65, 0x87, 0x4e, 0xf6, 0x00, 0x00,
 	}
 
-	temporaryDirectory               = temporaryDirectoryOrPanic()
-	SRGBV2MicroICCProfilePath        = filepath.Join(temporaryDirectory, "srgb_v2_micro.icc")
-	SGrayV2MicroICCProfilePath       = filepath.Join(temporaryDirectory, "sgray_v2_micro.icc")
-	SRGBIEC6196621ICCProfilePath     = filepath.Join(temporaryDirectory, "srgb_iec61966_2_1.icc")
-	GenericGrayGamma22ICCProfilePath = filepath.Join(temporaryDirectory, "generic_gray_gamma_2_2.icc")
+	temporaryDirectory               string
+	SRGBV2MicroICCProfilePath        string
+	SGrayV2MicroICCProfilePath       string
+	SRGBIEC6196621ICCProfilePath     string
+	GenericGrayGamma22ICCProfilePath string
 )
 
-func initializeICCProfiles() {
+func initializeICCProfiles(tempDir string) {
+	if tempDir != "" {
+		temporaryDirectory = tempDir
+	} else {
+		temporaryDirectory = temporaryDirectoryOrPanic()
+	}
+
+	SRGBV2MicroICCProfilePath = filepath.Join(temporaryDirectory, "srgb_v2_micro.icc")
+	SGrayV2MicroICCProfilePath = filepath.Join(temporaryDirectory, "sgray_v2_micro.icc")
+	SRGBIEC6196621ICCProfilePath = filepath.Join(temporaryDirectory, "srgb_iec61966_2_1.icc")
+	GenericGrayGamma22ICCProfilePath = filepath.Join(temporaryDirectory, "generic_gray_gamma_2_2.icc")
+
 	storeIccProfile(SRGBV2MicroICCProfilePath, sRGBV2MicroICCProfile)
 	storeIccProfile(SGrayV2MicroICCProfilePath, sGrayV2MicroICCProfile)
 	storeIccProfile(SRGBIEC6196621ICCProfilePath, sRGBIEC6196621ICCProfile)


### PR DESCRIPTION
This config option allows the caller to specify a preexisting temporary directory instead of relying on the ability to create one at runtime. This can be important in setups where a shell or mkdir are unavailable at runtime.