### PR TITLE
Added missing finalizer method

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -544,10 +544,7 @@ func Identity(ushort bool) (*ImageRef, error) {
 // Black creates a new black image of the specified size
 func Black(width, height int) (*ImageRef, error) {
 	vipsImage, err := vipsBlack(width, height)
-	imageRef := &ImageRef{
-		image: vipsImage,
-	}
-	runtime.SetFinalizer(imageRef, finalizeImage)
+	imageRef := newImageRef(vipsImage, ImageTypeUnknown, ImageTypeUnknown, nil)
 	return imageRef, err
 }
 
@@ -1116,7 +1113,8 @@ func (r *ImageRef) BandSplit() ([]*ImageRef, error) {
 		if err != nil {
 			return out, err
 		}
-		out = append(out, &ImageRef{image: img})
+		imageRef := newImageRef(img, ImageTypeUnknown, ImageTypeUnknown, nil)
+		out = append(out, imageRef)
 	}
 	return out, nil
 }


### PR DESCRIPTION
In a few methods in `image.go` the default constructor for creating an ImageRef object was getting used.

```
 &ImageRef{image: out}
```
The problem with this is that the `finalizer` is not set on these objects and thus `Close()` is never called. This keeps on filling the memory with zombie objects.

Similar issue listed here: https://github.com/davidbyttow/govips/issues/334 and https://github.com/davidbyttow/govips/pull/336