### PR TITLE
Fix AvifExportParams StripMetadata

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -362,7 +362,7 @@ int set_heifsave_options(VipsOperation *operation, SaveParams *params) {
 
 // https://github.com/libvips/libvips/blob/master/libvips/foreign/heifsave.c#L653
 int set_avifsave_options(VipsOperation *operation, SaveParams *params) {
-  int ret = vips_object_set(VIPS_OBJECT(operation), "compression",
+  int ret = vips_object_set(VIPS_OBJECT(operation), "strip", params->stripMetadata, "compression",
                             VIPS_FOREIGN_HEIF_COMPRESSION_AV1, "lossless",
                             params->heifLossless, NULL);
 

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -423,6 +423,7 @@ func vipsSaveAVIFToBuffer(in *C.VipsImage, params AvifExportParams) ([]byte, err
 
 	p := C.create_save_params(C.AVIF)
 	p.inputImage = in
+	p.stripMetadata = C.int(boolToInt(params.StripMetadata))
 	p.outputFormat = C.AVIF
 	p.quality = C.int(params.Quality)
 	p.heifLossless = C.int(boolToInt(params.Lossless))


### PR DESCRIPTION
The StripMetadata param in AvifExportParams was ignored.