### PR TITLE
Add min_size, kmin and kmax options to webp export params

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -290,6 +290,9 @@ int set_webpsave_options(VipsOperation *operation, SaveParams *params) {
                       "near_lossless", params->webpNearLossless,
                       "reduction_effort", params->webpReductionEffort,
                       "profile", params->webpIccProfile ? params->webpIccProfile : "none",
+                      "min_size", params->webpMinSize,
+                      "kmin", params->webpKMin,
+                      "kmax", params->webpKMax,
                       NULL);
 
   if (!ret && params->quality) {
@@ -542,6 +545,9 @@ static SaveParams defaultSaveParams = {
     .webpNearLossless = FALSE,
     .webpReductionEffort = 4,
     .webpIccProfile = NULL,
+    .webpKMax = 0,
+    .webpKMin = 0,
+    .webpMinSize = FALSE,
 
     .heifBitdepth = 8,
     .heifLossless = FALSE,

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -388,6 +388,9 @@ func vipsSaveWebPToBuffer(in *C.VipsImage, params WebpExportParams) ([]byte, err
 	p.webpLossless = C.int(boolToInt(params.Lossless))
 	p.webpNearLossless = C.int(boolToInt(params.NearLossless))
 	p.webpReductionEffort = C.int(params.ReductionEffort)
+	p.webpMinSize = C.int(boolToInt(params.MinSize))
+	p.webpKMin = C.int(params.MinKeyFrames)
+	p.webpKMax = C.int(params.MaxKeyFrames)
 
 	if params.IccProfile != "" {
 		p.webpIccProfile = C.CString(params.IccProfile)

--- a/vips/foreign.h
+++ b/vips/foreign.h
@@ -107,6 +107,9 @@ typedef struct SaveParams {
   BOOL webpNearLossless;
   int webpReductionEffort;
   char *webpIccProfile;
+  BOOL webpMinSize;
+  int webpKMin;
+  int webpKMax;
 
   // HEIF - https://github.com/libvips/libvips/blob/master/libvips/foreign/heifsave.c#L71
   int heifBitdepth; // Bitdepth to save at for >8 bit images

--- a/vips/image.go
+++ b/vips/image.go
@@ -272,6 +272,8 @@ func NewPngExportParams() *PngExportParams {
 }
 
 // WebpExportParams are options when exporting a WEBP to file or buffer
+// see https://www.libvips.org/API/current/VipsForeignSave.html#vips-webpsave
+// for details on each parameter
 type WebpExportParams struct {
 	StripMetadata   bool
 	Quality         int
@@ -279,6 +281,9 @@ type WebpExportParams struct {
 	NearLossless    bool
 	ReductionEffort int
 	IccProfile      string
+	MinSize         bool
+	MinKeyFrames    int
+	MaxKeyFrames    int
 }
 
 // NewWebpExportParams creates default values for an export of a WEBP image.

--- a/vips/image_gif_test.go
+++ b/vips/image_gif_test.go
@@ -40,6 +40,18 @@ func TestImage_GIF_Animated_to_WebP(t *testing.T) {
 		exportWebp(NewWebpExportParams()))
 }
 
+func TestImage_GIF_Animated_to_WebP_Extra_Params(t *testing.T) {
+	exportParams := NewWebpExportParams()
+	exportParams.MaxKeyFrames = 100
+	exportParams.MinKeyFrames = 10
+	exportParams.MinSize = true
+	goldenAnimatedTest(t, resources+"gif-animated.gif",
+		3,
+		nil,
+		nil,
+		exportWebp(exportParams))
+}
+
 func TestImage_GIF_Animated_Resize(t *testing.T) {
 	goldenAnimatedTest(t, resources+"gif-animated.gif",
 		3,


### PR DESCRIPTION
This PR adds new params that can be used to optimize exported webp animations.