### PR TITLE
add missing ret variable assignment

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -296,7 +296,7 @@ int set_webpsave_options(VipsOperation *operation, SaveParams *params) {
                       NULL);
 
   if (!ret && params->quality) {
-    vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
+    ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
   return ret;


### PR DESCRIPTION
Attempts to fix an issue with exporting large WebP files, see #404 

Attempt number two, locally one of the tests fails but that might just be an issue with my machine. If not, it is most likely an issue with the test.

Edit: It worked!