### PR TITLE
Refine `GifExportParams`

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -332,7 +332,7 @@ int set_magicksave_options(VipsOperation *operation, SaveParams *params) {
 int set_gifsave_options(VipsOperation *operation, SaveParams *params) {
   int ret = 0;
   // See for argument values: https://www.libvips.org/API/current/VipsForeignSave.html#vips-gifsave
-  if (params->gifDither > 1 && params->gifDither <= 10) {
+  if (params->gifDither > 0.0 && params->gifDither <= 10) {
     ret = vips_object_set(VIPS_OBJECT(operation), "dither", params->gifDither, NULL);
   }
   if (params->gifEffort >= 1 && params->gifEffort <= 10) {

--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -319,7 +319,8 @@ int set_tiffsave_options(VipsOperation *operation, SaveParams *params) {
 
 // https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-magicksave-buffer
 int set_magicksave_options(VipsOperation *operation, SaveParams *params) {
-  int ret = vips_object_set(VIPS_OBJECT(operation), "format", "GIF", NULL);
+  int ret = vips_object_set(VIPS_OBJECT(operation), "format", "GIF", "bitdepth", params->gifBitdepth, NULL);
+
   if (!ret && params->quality) {
     ret = vips_object_set(VIPS_OBJECT(operation), "quality", params->quality,
                           NULL);
@@ -331,7 +332,7 @@ int set_magicksave_options(VipsOperation *operation, SaveParams *params) {
 int set_gifsave_options(VipsOperation *operation, SaveParams *params) {
   int ret = 0;
   // See for argument values: https://www.libvips.org/API/current/VipsForeignSave.html#vips-gifsave
-  if (params->gifDither > 0.0 && params->gifDither <= 1.0) {
+  if (params->gifDither > 1 && params->gifDither <= 10) {
     ret = vips_object_set(VIPS_OBJECT(operation), "dither", params->gifDither, NULL);
   }
   if (params->gifEffort >= 1 && params->gifEffort <= 10) {

--- a/vips/image.go
+++ b/vips/image.go
@@ -314,12 +314,14 @@ func NewTiffExportParams() *TiffExportParams {
 	}
 }
 
+// GifExportParams are options when exporting a GIF to file or buffer
+// Please note that if vips version is above 8.12, then `vips_gifsave_buffer` is used, and only `Dither`, `Effort`, `Bitdepth` is used.
+// If vips version is below 8.12, then `vips_magicksave_buffer` is used, and only `Bitdepth`, `Quality` is used.
 type GifExportParams struct {
-	StripMetadata bool
-	Quality       int
-	Dither        float64
-	Effort        int
-	Bitdepth      int
+	Quality  int
+	Dither   float64
+	Effort   int
+	Bitdepth int
 }
 
 // NewGifExportParams creates default values for an export of a GIF image.

--- a/vips/image.go
+++ b/vips/image.go
@@ -317,12 +317,13 @@ func NewTiffExportParams() *TiffExportParams {
 // GifExportParams are options when exporting a GIF to file or buffer
 // Please note that if vips version is above 8.12, then `vips_gifsave_buffer` is used, and only `Dither`, `Effort`, `Bitdepth` is used.
 // If vips version is below 8.12, then `vips_magicksave_buffer` is used, and only `Bitdepth`, `Quality` is used.
+// StripMetadata does nothing to Gif images.
 type GifExportParams struct {
 	StripMetadata bool
-	Quality  int
-	Dither   float64
-	Effort   int
-	Bitdepth int
+	Quality       int
+	Dither        float64
+	Effort        int
+	Bitdepth      int
 }
 
 // NewGifExportParams creates default values for an export of a GIF image.

--- a/vips/image.go
+++ b/vips/image.go
@@ -318,6 +318,7 @@ func NewTiffExportParams() *TiffExportParams {
 // Please note that if vips version is above 8.12, then `vips_gifsave_buffer` is used, and only `Dither`, `Effort`, `Bitdepth` is used.
 // If vips version is below 8.12, then `vips_magicksave_buffer` is used, and only `Bitdepth`, `Quality` is used.
 type GifExportParams struct {
+	StripMetadata bool
 	Quality  int
 	Dither   float64
 	Effort   int


### PR DESCRIPTION
In response to https://github.com/davidbyttow/govips/issues/359#issuecomment-2002981134

Changes:
1. Added notes on `GifExportParams` to tell users that different vips version will use different params
2. `StripMetadata` is removed as `libvips` does not support this function on GIFs, I've tried pass it in with `VIPS_OBJECT(operation), "strip", params->stripMetadata,`, the output image remains the same.
3. Passed in `bitdepth` in early vips version

However this PR is not finished, I've found several problems here.
1. No matter how I change GifExportParams's `Dither`, `Effort` or `Bitdepth`, the output image's sha256sum remains the same
2. In the current `set_gifsave_options`, only one parameter can be used with passed in multiple parameters, as below
```c
  // See for argument values: https://www.libvips.org/API/current/VipsForeignSave.html#vips-gifsave
  if (params->gifDither > 1 && params->gifDither <= 10) {
    ret = vips_object_set(VIPS_OBJECT(operation), "dither", params->gifDither, NULL);
  }
  if (params->gifEffort >= 1 && params->gifEffort <= 10) {
    ret = vips_object_set(VIPS_OBJECT(operation), "effort", params->gifEffort, NULL);
  }
  if (params->gifBitdepth >= 1 && params->gifBitdepth <= 8) {
      ret = vips_object_set(VIPS_OBJECT(operation), "bitdepth", params->gifBitdepth, NULL);
  }
```
But, as different parameters will result in same output image, I'm not sure why this is happening.