### PR TITLE
Replace `io/ioutil` with preferred packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@ all: deps build test
 
 .PHONY: deps
 deps:
-	CGO_CFLAGS_ALLOW=-Xpreprocessor go get ./...
+	CGO_CFLAGS_ALLOW=-Xpreprocessor go get -v -t -d ./...
 
 .PHONY: build
 build:
-	CGO_CFLAGS_ALLOW=-Xpreprocessor go build ./vips
+	CGO_CFLAGS_ALLOW=-Xpreprocessor go build -v ./vips
 
 .PHONY: test
 test:
-	CGO_CFLAGS_ALLOW=-Xpreprocessor go test -v ./...
+	CGO_CFLAGS_ALLOW=-Xpreprocessor go test -v -coverprofile=profile.cov ./...
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,30 @@
 all: deps build test
 
-deps: FORCE
+.PHONY: deps
+deps:
 	CGO_CFLAGS_ALLOW=-Xpreprocessor go get ./...
 
-build: FORCE
+.PHONY: build
+build:
 	CGO_CFLAGS_ALLOW=-Xpreprocessor go build ./vips
 
-test: FORCE
+.PHONY: test
+test:
 	CGO_CFLAGS_ALLOW=-Xpreprocessor go test -v ./...
 
-FORCE:
+.PHONY: clean
+clean:
+	go clean
+
+.PHONY: clean-cache
+clean-cache:
+	# Purge build cache and test cache.
+	# When something went wrong on building or testing, try this.
+	-go clean -testcache
+	-go clean -cache
+
+.PHONY: distclean
+distclean:
+	-go clean -testcache
+	-go clean -cache
+	-git clean -f -x

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The intent for this is to enable developers to build extremely fast image proces
 
 -   [libvips](https://github.com/libvips/libvips) 8.10+
 -   C compatible compiler such as gcc 4.6+ or clang 3.0+
--   Go 1.14+
+-   Go 1.16+
 
 ## Dependencies
 
@@ -53,7 +53,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/davidbyttow/govips/v2/vips"
@@ -79,7 +78,7 @@ func main() {
 
 	ep := vips.NewDefaultJPEGExportParams()
 	image1bytes, _, err := image1.Export(ep)
-	err = ioutil.WriteFile("output.jpg", image1bytes, 0644)
+	err = os.WriteFile("output.jpg", image1bytes, 0644)
 	checkError(err)
 
 }

--- a/examples/jpeg/example_mozjpeg_image.go
+++ b/examples/jpeg/example_mozjpeg_image.go
@@ -4,7 +4,6 @@ package vips_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/davidbyttow/govips/v2/vips"
@@ -44,5 +43,5 @@ func ExampleMozJPEGEncode() {
 
 	imageBytes, _, err := inputImage.ExportJpeg(ep)
 	checkError(err)
-	checkError(ioutil.WriteFile("examples/jpeg/mozjpeg-output-govips.jpeg", imageBytes, 0644))
+	checkError(os.WriteFile("examples/jpeg/mozjpeg-output-govips.jpeg", imageBytes, 0644))
 }

--- a/examples/logging/example_logging_test.go
+++ b/examples/logging/example_logging_test.go
@@ -2,7 +2,6 @@ package package_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -64,6 +63,6 @@ func main() {
 
 	image1bytes, _, err := image1.ExportJpeg(nil)
 	checkError(err)
-	err = ioutil.WriteFile("output.jpg", image1bytes, 0644)
+	err = os.WriteFile("output.jpg", image1bytes, 0644)
 	checkError(err)
 }

--- a/examples/thumbnail/bench_test.go
+++ b/examples/thumbnail/bench_test.go
@@ -2,9 +2,10 @@ package thumbnail
 
 import (
 	"fmt"
-	"github.com/davidbyttow/govips/v2/vips"
-	"io/ioutil"
+	"os"
 	"testing"
+
+	"github.com/davidbyttow/govips/v2/vips"
 )
 
 var file = "../../resources/jpg-24bit-icc-iec.jpg"
@@ -43,7 +44,7 @@ func BenchmarkNewImageFromFile(b *testing.B) {
 
 func BenchmarkNewImageFromBuffer(b *testing.B) {
 	resizeToTest := func(size int) {
-		buf, err := ioutil.ReadFile(file)
+		buf, err := os.ReadFile(file)
 		if err != nil {
 			panic(err)
 		}
@@ -94,7 +95,7 @@ func BenchmarkNewThumbnailFromFile(b *testing.B) {
 
 func BenchmarkNewThumbnailFromBuffer(b *testing.B) {
 	resizeToTest := func(size int) {
-		buf, err := ioutil.ReadFile(file)
+		buf, err := os.ReadFile(file)
 		if err != nil {
 			panic(err)
 		}

--- a/examples/tiff/example_tiff_image.go
+++ b/examples/tiff/example_tiff_image.go
@@ -4,7 +4,6 @@ package package_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/davidbyttow/govips/v2/vips"
@@ -33,6 +32,6 @@ func main() {
 	exportParams := vips.NewTiffExportParams()
 	exportParams.Quality = 100
 	imageBytes, _, err := inputImage.ExportTiff(exportParams)
-	err = ioutil.WriteFile("examples/tiff/output-govips.tiff", imageBytes, 0644)
+	err = os.WriteFile("examples/tiff/output-govips.tiff", imageBytes, 0644)
 	checkError(err)
 }

--- a/vips/foreign_test.go
+++ b/vips/foreign_test.go
@@ -1,7 +1,7 @@
 package vips
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +10,7 @@ import (
 func Test_DetermineImageType__JPEG(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "jpg-24bit-icc-iec.jpg")
+	buf, err := os.ReadFile(resources + "jpg-24bit-icc-iec.jpg")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -21,7 +21,7 @@ func Test_DetermineImageType__JPEG(t *testing.T) {
 func Test_DetermineImageType__HEIF_HEIC(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "heic-24bit-exif.heic")
+	buf, err := os.ReadFile(resources + "heic-24bit-exif.heic")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -32,7 +32,7 @@ func Test_DetermineImageType__HEIF_HEIC(t *testing.T) {
 func Test_DetermineImageType__HEIF_MIF1(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "heic-24bit.heic")
+	buf, err := os.ReadFile(resources + "heic-24bit.heic")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -43,7 +43,7 @@ func Test_DetermineImageType__HEIF_MIF1(t *testing.T) {
 func Test_DetermineImageType__PNG(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "png-24bit+alpha.png")
+	buf, err := os.ReadFile(resources + "png-24bit+alpha.png")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -54,7 +54,7 @@ func Test_DetermineImageType__PNG(t *testing.T) {
 func Test_DetermineImageType__TIFF(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "tif.tif")
+	buf, err := os.ReadFile(resources + "tif.tif")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -65,7 +65,7 @@ func Test_DetermineImageType__TIFF(t *testing.T) {
 func Test_DetermineImageType__WEBP(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "webp+alpha.webp")
+	buf, err := os.ReadFile(resources + "webp+alpha.webp")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -76,7 +76,7 @@ func Test_DetermineImageType__WEBP(t *testing.T) {
 func Test_DetermineImageType__SVG(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "svg.svg")
+	buf, err := os.ReadFile(resources + "svg.svg")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -87,7 +87,7 @@ func Test_DetermineImageType__SVG(t *testing.T) {
 func Test_DetermineImageType__SVG_1(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "svg_1.svg")
+	buf, err := os.ReadFile(resources + "svg_1.svg")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -98,7 +98,7 @@ func Test_DetermineImageType__SVG_1(t *testing.T) {
 func Test_DetermineImageType__PDF(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "pdf.pdf")
+	buf, err := os.ReadFile(resources + "pdf.pdf")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -109,7 +109,7 @@ func Test_DetermineImageType__PDF(t *testing.T) {
 func Test_DetermineImageType__BMP(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "bmp.bmp")
+	buf, err := os.ReadFile(resources + "bmp.bmp")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -120,7 +120,7 @@ func Test_DetermineImageType__BMP(t *testing.T) {
 func Test_DetermineImageType__AVIF(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "avif-8bit.avif")
+	buf, err := os.ReadFile(resources + "avif-8bit.avif")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -131,7 +131,7 @@ func Test_DetermineImageType__AVIF(t *testing.T) {
 func Test_DetermineImageType__JP2K(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "jp2k-orientation-6.jp2")
+	buf, err := os.ReadFile(resources + "jp2k-orientation-6.jp2")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 
@@ -142,7 +142,7 @@ func Test_DetermineImageType__JP2K(t *testing.T) {
 func Test_DetermineImageType__JXL(t *testing.T) {
 	Startup(&Config{})
 
-	buf, err := ioutil.ReadFile(resources + "jxl-8bit-grey-icc-dot-gain.jxl")
+	buf, err := os.ReadFile(resources + "jxl-8bit-grey-icc-dot-gain.jxl")
 	assert.NoError(t, err)
 	assert.NotNil(t, buf)
 

--- a/vips/icc_profiles.go
+++ b/vips/icc_profiles.go
@@ -2,7 +2,7 @@ package vips
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -659,14 +659,14 @@ func initializeICCProfiles() {
 }
 
 func storeIccProfile(path string, data []byte) {
-	err := ioutil.WriteFile(path, data, 0600)
+	err := os.WriteFile(path, data, 0600)
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't store temporary file for ICC profile in '%v': %v", path, err.Error()))
 	}
 }
 
 func temporaryDirectoryOrPanic() string {
-	temporaryDirectory, err := ioutil.TempDir("", "govips-")
+	temporaryDirectory, err := os.MkdirTemp("", "govips-")
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't create temporary directory: %v", err.Error()))
 	}

--- a/vips/icc_profiles_test.go
+++ b/vips/icc_profiles_test.go
@@ -1,9 +1,10 @@
 package vips
 
 import (
-	"github.com/stretchr/testify/require"
-	"io/ioutil"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +19,7 @@ func Test_ICCProfileInitialisation(t *testing.T) {
 }
 
 func assertIccProfile(t *testing.T, expectedProfile []byte, path string) {
-	loadedProfile, err := ioutil.ReadFile(path)
+	loadedProfile, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Equal(t, expectedProfile, loadedProfile)
 }

--- a/vips/image.go
+++ b/vips/image.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"image"
 	"io"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -415,7 +415,7 @@ func NewJxlExportParams() *JxlExportParams {
 
 // NewImageFromReader loads an ImageRef from the given reader
 func NewImageFromReader(r io.Reader) (*ImageRef, error) {
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func NewImageFromFile(file string) (*ImageRef, error) {
 
 // LoadImageFromFile loads an image from file and creates a new ImageRef
 func LoadImageFromFile(file string, params *ImportParams) (*ImageRef, error) {
-	buf, err := ioutil.ReadFile(file)
+	buf, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -817,7 +817,7 @@ func (r *ImageRef) SetPageDelay(delay []int) error {
 }
 
 // Export creates a byte array of the image for use.
-// The function returns a byte array that can be written to a file e.g. via ioutil.WriteFile().
+// The function returns a byte array that can be written to a file e.g. via os.WriteFile().
 // N.B. govips does not currently have built-in support for directly exporting to a file.
 // The function also returns a copy of the image metadata as well as an error.
 // Deprecated: Use ExportNative or format-specific Export methods

--- a/vips/image_golden_test.go
+++ b/vips/image_golden_test.go
@@ -5,7 +5,7 @@ import (
 	"image"
 	jpeg2 "image/jpeg"
 	"image/png"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -1078,7 +1078,7 @@ func goldenCreateTest(
 
 	assertGoldenMatch(t, path, buf, metadata.Format)
 
-	buf2, err := ioutil.ReadFile(path)
+	buf2, err := os.ReadFile(path)
 	require.NoError(t, err)
 
 	img2, err := createFromBuffer(buf2)
@@ -1137,12 +1137,12 @@ func assertGoldenMatch(t *testing.T, file string, buf []byte, format ImageType) 
 	ext := format.FileExt()
 	goldenFile := prefix + "-" + getEnvironment() + ".golden" + ext
 
-	golden, _ := ioutil.ReadFile(goldenFile)
+	golden, _ := os.ReadFile(goldenFile)
 	if golden != nil {
 		sameAsGolden := assert.True(t, bytes.Equal(buf, golden), "Actual image (size=%d) didn't match expected golden file=%s (size=%d)", len(buf), goldenFile, len(golden))
 		if !sameAsGolden {
 			failed := prefix + "-" + getEnvironment() + ".failed" + ext
-			err := ioutil.WriteFile(failed, buf, 0666)
+			err := os.WriteFile(failed, buf, 0666)
 			if err != nil {
 				panic(err)
 			}
@@ -1151,7 +1151,7 @@ func assertGoldenMatch(t *testing.T, file string, buf []byte, format ImageType) 
 	}
 
 	t.Log("writing golden file: " + goldenFile)
-	err := ioutil.WriteFile(goldenFile, buf, 0644)
+	err := os.WriteFile(goldenFile, buf, 0644)
 	assert.NoError(t, err)
 }
 

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -3,7 +3,6 @@ package vips
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"runtime"
@@ -23,7 +22,7 @@ func TestMain(m *testing.M) {
 func TestImageRef_WebP(t *testing.T) {
 	Startup(nil)
 
-	srcBytes, err := ioutil.ReadFile(resources + "webp+alpha.webp")
+	srcBytes, err := os.ReadFile(resources + "webp+alpha.webp")
 	require.NoError(t, err)
 
 	src := bytes.NewReader(srcBytes)
@@ -38,7 +37,7 @@ func TestImageRef_WebP(t *testing.T) {
 func TestImageRef_WebP__ReducedEffort(t *testing.T) {
 	Startup(nil)
 
-	srcBytes, err := ioutil.ReadFile(resources + "webp+alpha.webp")
+	srcBytes, err := os.ReadFile(resources + "webp+alpha.webp")
 	require.NoError(t, err)
 
 	src := bytes.NewReader(srcBytes)
@@ -55,7 +54,7 @@ func TestImageRef_WebP__ReducedEffort(t *testing.T) {
 func TestImageRef_WebP__NearLossless(t *testing.T) {
 	Startup(nil)
 
-	srcBytes, err := ioutil.ReadFile(resources + "webp+alpha.webp")
+	srcBytes, err := os.ReadFile(resources + "webp+alpha.webp")
 	require.NoError(t, err)
 
 	src := bytes.NewReader(srcBytes)
@@ -72,7 +71,7 @@ func TestImageRef_WebP__NearLossless(t *testing.T) {
 func TestImageRef_PNG(t *testing.T) {
 	Startup(nil)
 
-	srcBytes, err := ioutil.ReadFile(resources + "png-24bit.png")
+	srcBytes, err := os.ReadFile(resources + "png-24bit.png")
 	require.NoError(t, err)
 
 	src := bytes.NewReader(srcBytes)
@@ -90,7 +89,7 @@ func TestImageRef_PNG(t *testing.T) {
 func TestImageRef_HEIF(t *testing.T) {
 	Startup(nil)
 
-	raw, err := ioutil.ReadFile(resources + "heic-24bit-exif.heic")
+	raw, err := os.ReadFile(resources + "heic-24bit-exif.heic")
 	require.NoError(t, err)
 
 	img, err := NewImageFromBuffer(raw)
@@ -105,7 +104,7 @@ func TestImageRef_HEIF(t *testing.T) {
 func TestImageRef_HEIF_MIF1(t *testing.T) {
 	Startup(nil)
 
-	raw, err := ioutil.ReadFile(resources + "heic-24bit.heic")
+	raw, err := os.ReadFile(resources + "heic-24bit.heic")
 	require.NoError(t, err)
 
 	img, err := NewImageFromBuffer(raw)
@@ -120,7 +119,7 @@ func TestImageRef_HEIF_MIF1(t *testing.T) {
 func TestImageRef_HEIF_ftypmsf1(t *testing.T) {
 	Startup(nil)
 
-	raw, err := ioutil.ReadFile(resources + "heic-ftypmsf1.heic")
+	raw, err := os.ReadFile(resources + "heic-ftypmsf1.heic")
 	require.NoError(t, err)
 
 	img, err := NewImageFromBuffer(raw)
@@ -135,7 +134,7 @@ func TestImageRef_HEIF_ftypmsf1(t *testing.T) {
 func TestImageRef_BMP__ImplicitConversionToPNG(t *testing.T) {
 	Startup(nil)
 
-	raw, err := ioutil.ReadFile(resources + "bmp.bmp")
+	raw, err := os.ReadFile(resources + "bmp.bmp")
 	require.NoError(t, err)
 
 	img, err := NewImageFromBuffer(raw)
@@ -152,7 +151,7 @@ func TestImageRef_BMP__ImplicitConversionToPNG(t *testing.T) {
 func TestImageRef_SVG(t *testing.T) {
 	Startup(nil)
 
-	raw, err := ioutil.ReadFile(resources + "svg.svg")
+	raw, err := os.ReadFile(resources + "svg.svg")
 	require.NoError(t, err)
 
 	img, err := NewImageFromBuffer(raw)
@@ -165,7 +164,7 @@ func TestImageRef_SVG(t *testing.T) {
 func TestImageRef_SVG_1(t *testing.T) {
 	Startup(nil)
 
-	raw, err := ioutil.ReadFile(resources + "svg_1.svg")
+	raw, err := os.ReadFile(resources + "svg_1.svg")
 	require.NoError(t, err)
 
 	img, err := NewImageFromBuffer(raw)
@@ -178,7 +177,7 @@ func TestImageRef_SVG_1(t *testing.T) {
 func TestImageRef_SVG_2(t *testing.T) {
 	Startup(nil)
 
-	raw, err := ioutil.ReadFile(resources + "svg_2.svg")
+	raw, err := os.ReadFile(resources + "svg_2.svg")
 	require.NoError(t, err)
 
 	img, err := NewImageFromBuffer(raw)
@@ -191,7 +190,7 @@ func TestImageRef_SVG_2(t *testing.T) {
 func TestImageRef_OverSizedMetadata(t *testing.T) {
 	Startup(nil)
 
-	srcBytes, err := ioutil.ReadFile(resources + "png-bad-metadata.png")
+	srcBytes, err := os.ReadFile(resources + "png-bad-metadata.png")
 	require.NoError(t, err)
 
 	src := bytes.NewReader(srcBytes)
@@ -749,7 +748,7 @@ func TestCopy(t *testing.T) {
 func BenchmarkExportImage(b *testing.B) {
 	Startup(nil)
 
-	fileBuf, err := ioutil.ReadFile(resources + "heic-24bit.heic")
+	fileBuf, err := os.ReadFile(resources + "heic-24bit.heic")
 	require.NoError(b, err)
 
 	img, err := NewImageFromBuffer(fileBuf)
@@ -767,7 +766,7 @@ func BenchmarkExportImage(b *testing.B) {
 func BenchmarkOpenBMPImage(b *testing.B) {
 	Startup(nil)
 
-	fileBuf, err := ioutil.ReadFile(resources + "large.bmp")
+	fileBuf, err := os.ReadFile(resources + "large.bmp")
 	require.NoError(b, err)
 
 	b.SetParallelism(100)
@@ -1057,7 +1056,7 @@ func TestImageRef_Linear_Fails(t *testing.T) {
 func TestImageRef_AVIF(t *testing.T) {
 	Startup(nil)
 
-	raw, err := ioutil.ReadFile(resources + "avif-8bit.avif")
+	raw, err := os.ReadFile(resources + "avif-8bit.avif")
 	require.NoError(t, err)
 
 	img, err := NewImageFromBuffer(raw)
@@ -1075,7 +1074,7 @@ func TestImageRef_JP2K(t *testing.T) {
 	}
 	Startup(nil)
 
-	raw, err := ioutil.ReadFile(resources + "jp2k-orientation-6.jp2")
+	raw, err := os.ReadFile(resources + "jp2k-orientation-6.jp2")
 	require.NoError(t, err)
 
 	img, err := NewImageFromBuffer(raw)
@@ -1091,7 +1090,7 @@ func TestImageRef_JP2K(t *testing.T) {
 func TestImageRef_CorruptedJPEG(t *testing.T) {
 	Startup(nil)
 
-	raw, err := ioutil.ReadFile(resources + "jpg-corruption.jpg")
+	raw, err := os.ReadFile(resources + "jpg-corruption.jpg")
 	require.NoError(t, err)
 
 	img, err := NewImageFromBuffer(raw)

--- a/vips/mem_tests/image_test.go
+++ b/vips/mem_tests/image_test.go
@@ -2,7 +2,6 @@ package mem_tests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -29,7 +28,7 @@ func TestMain(m *testing.M) {
 func TestMemoryLeak(t *testing.T) {
 	vips.Startup(nil)
 
-	buf, err := ioutil.ReadFile(resources + "png-24bit.png")
+	buf, err := os.ReadFile(resources + "png-24bit.png")
 	require.NoError(t, err)
 
 	iteration := func() {

--- a/vips/resample.go
+++ b/vips/resample.go
@@ -3,7 +3,7 @@ package vips
 // #include "resample.h"
 import "C"
 import (
-	"io/ioutil"
+	"os"
 	"runtime"
 	"unsafe"
 )
@@ -75,7 +75,7 @@ func vipsThumbnailFromFile(filename string, width, height int, crop Interesting,
 
 	if err := C.thumbnail(cFileName, &out, C.int(width), C.int(height), C.int(crop), C.int(size)); err != 0 {
 		err := handleImageError(out)
-		if src, err2 := ioutil.ReadFile(filename); err2 == nil {
+		if src, err2 := os.ReadFile(filename); err2 == nil {
 			if isBMP(src) {
 				if src2, err3 := bmpToPNG(src); err3 == nil {
 					return vipsThumbnailFromBuffer(src2, width, height, crop, size, params)


### PR DESCRIPTION
# Summary

- replace `io/ioutil` with preferred packages.
- improve Makefile with [Phony targets](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html)

# Test results

Please see [workflow logs](https://github.com/FomalhautWeisszwerg/govips/actions/runs/8939458962/job/24555523739).

# Details

## Replacing `io/ioutil`  with preferred packages

Since Go 1.16, the `io/ioutil` package has been [marked as deprecated](https://pkg.go.dev/io/ioutil@go1.22.2#pkg-overview). The functions provided by `io/ioutil` are now provided by `io` or `os` packages with no functionality change and now using these packages are preferred.

## Improves of Makefile

To avoid a conflict with a file or directory of the same name and to improve performance, [Phony Targets](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) are used.

For more convenience, `make clean`, `make clean-cache`, and `make distclean` commands have been added.


Thank you for reviewing :-)
