### PR TITLE
Add test to validate resizing of animated image.

### DIFF
--- a/vips/error.go
+++ b/vips/error.go
@@ -13,6 +13,8 @@ import (
 var (
 	// ErrUnsupportedImageFormat when image type is unsupported
 	ErrUnsupportedImageFormat = errors.New("unsupported image format")
+	// ErrInvalidScaleForAnimatedImage when an animated image will not resize correctly with the given scale value
+	ErrInvalidScaleForAnimatedImage = errors.New("invalid scale for animated image")
 )
 
 func handleImageError(out *C.VipsImage) error {

--- a/vips/image.go
+++ b/vips/image.go
@@ -1781,6 +1781,18 @@ func (r *ImageRef) ResizeWithVScale(hScale, vScale float64, kernel Kernel) error
 
 	pages := r.Pages()
 	pageHeight := r.GetPageHeight()
+	newPageHeight := 0
+
+	if pages > 1 {
+		scale := hScale
+		if vScale != -1 {
+			scale = vScale
+		}
+		newPageHeight = int(float64(pageHeight) * scale)
+		if float64(newPageHeight) != float64(pageHeight)*scale {
+			return ErrInvalidScaleForAnimatedImage
+		}
+	}
 
 	out, err := vipsResizeWithVScale(r.image, hScale, vScale, kernel)
 	if err != nil {
@@ -1789,11 +1801,6 @@ func (r *ImageRef) ResizeWithVScale(hScale, vScale float64, kernel Kernel) error
 	r.setImage(out)
 
 	if pages > 1 {
-		scale := hScale
-		if vScale != -1 {
-			scale = vScale
-		}
-		newPageHeight := int(float64(pageHeight)*scale + 0.5)
 		if err := r.SetPageHeight(newPageHeight); err != nil {
 			return err
 		}

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -209,6 +209,26 @@ func TestImageRef_Resize__Error(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestImageRef_Resize_Animated_CorrectScale(t *testing.T) {
+	Startup(nil)
+
+	image, err := NewImageFromFile(resources + "gif-animated.gif")
+	require.NoError(t, err)
+
+	err = image.Resize(0.5, KernelLanczos3)
+	require.NoError(t, err)
+}
+
+func TestImageRef_Resize_Animated_InvalidScale(t *testing.T) {
+	Startup(nil)
+
+	image, err := NewImageFromFile(resources + "gif-animated.gif")
+	require.NoError(t, err)
+
+	err = image.Resize(0.2, KernelLanczos3)
+	require.Error(t, err)
+}
+
 func TestImageRef_ExtractArea__Error(t *testing.T) {
 	Startup(nil)
 


### PR DESCRIPTION
This adds a test to the ImageRef.Resize functions to make sure when resizing an animated image that the correct scale is used to avoid unrolling the animated image.

See https://github.com/davidbyttow/govips/issues/350