### PR TITLE
Expose more Parameters for TIFF export

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -414,6 +414,10 @@ func vipsSaveTIFFToBuffer(in *C.VipsImage, params TiffExportParams) ([]byte, err
 	p.stripMetadata = C.int(boolToInt(params.StripMetadata))
 	p.quality = C.int(params.Quality)
 	p.tiffCompression = C.VipsForeignTiffCompression(params.Compression)
+	p.tiffPyramid = C.int(boolToInt(params.Pyramid))
+	p.tiffTile = C.int(boolToInt(params.Tile))
+	p.tiffTileHeight = C.int(params.TileHeight)
+	p.tiffTileWidth = C.int(params.TileWidth)
 
 	return vipsSaveToBuffer(p)
 }

--- a/vips/image.go
+++ b/vips/image.go
@@ -306,6 +306,10 @@ type TiffExportParams struct {
 	Quality       int
 	Compression   TiffCompression
 	Predictor     TiffPredictor
+	Pyramid       bool
+	Tile          bool
+	TileHeight    int
+	TileWidth     int
 }
 
 // NewTiffExportParams creates default values for an export of a TIFF image.
@@ -314,6 +318,10 @@ func NewTiffExportParams() *TiffExportParams {
 		Quality:     80,
 		Compression: TiffCompressionLzw,
 		Predictor:   TiffPredictorHorizontal,
+		Pyramid:     false,
+		Tile:        false,
+		TileHeight:  256,
+		TileWidth:   256,
 	}
 }
 


### PR DESCRIPTION
For tiled and/or pyramidal TIFF files, there are four more parameters needed.
These are already available at the C-part of govips. therefor exposing these variables in `TiffExportParams` should not interfere with any other parts of the library

Pyramid, Tile, TileHeight and TileWidth are the newly exposed variables in `TiffExportParams`.