### PR TITLE
Support vips 8.16.0

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -526,7 +526,7 @@ static SaveParams defaultSaveParams = {
     .stripMetadata = FALSE,
 
     .jpegOptimizeCoding = FALSE,
-    .jpegSubsample = VIPS_FOREIGN_JPEG_SUBSAMPLE_ON,
+    .jpegSubsample = VIPS_FOREIGN_SUBSAMPLE_ON,
     .jpegTrellisQuant = FALSE,
     .jpegOvershootDeringing = FALSE,
     .jpegOptimizeScans = FALSE,

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -19,10 +19,10 @@ type SubsampleMode int
 
 // SubsampleMode enum correlating to libvips subsample modes
 const (
-	VipsForeignSubsampleAuto SubsampleMode = C.VIPS_FOREIGN_JPEG_SUBSAMPLE_AUTO
-	VipsForeignSubsampleOn   SubsampleMode = C.VIPS_FOREIGN_JPEG_SUBSAMPLE_ON
-	VipsForeignSubsampleOff  SubsampleMode = C.VIPS_FOREIGN_JPEG_SUBSAMPLE_OFF
-	VipsForeignSubsampleLast SubsampleMode = C.VIPS_FOREIGN_JPEG_SUBSAMPLE_LAST
+	VipsForeignSubsampleAuto SubsampleMode = C.VIPS_FOREIGN_SUBSAMPLE_AUTO
+	VipsForeignSubsampleOn   SubsampleMode = C.VIPS_FOREIGN_SUBSAMPLE_ON
+	VipsForeignSubsampleOff  SubsampleMode = C.VIPS_FOREIGN_SUBSAMPLE_OFF
+	VipsForeignSubsampleLast SubsampleMode = C.VIPS_FOREIGN_SUBSAMPLE_LAST
 )
 
 // ImageType represents an image type
@@ -358,7 +358,7 @@ func vipsSaveJPEGToBuffer(in *C.VipsImage, params JpegExportParams) ([]byte, err
 	p.quality = C.int(params.Quality)
 	p.interlace = C.int(boolToInt(params.Interlace))
 	p.jpegOptimizeCoding = C.int(boolToInt(params.OptimizeCoding))
-	p.jpegSubsample = C.VipsForeignJpegSubsample(params.SubsampleMode)
+	p.jpegSubsample = C.VipsForeignSubsample(params.SubsampleMode)
 	p.jpegTrellisQuant = C.int(boolToInt(params.TrellisQuant))
 	p.jpegOvershootDeringing = C.int(boolToInt(params.OvershootDeringing))
 	p.jpegOptimizeScans = C.int(boolToInt(params.OptimizeScans))
@@ -463,7 +463,7 @@ func vipsSaveJP2KToBuffer(in *C.VipsImage, params Jp2kExportParams) ([]byte, err
 	p.jp2kLossless = C.int(boolToInt(params.Lossless))
 	p.jp2kTileWidth = C.int(params.TileWidth)
 	p.jp2kTileHeight = C.int(params.TileHeight)
-	p.jpegSubsample = C.VipsForeignJpegSubsample(params.SubsampleMode)
+	p.jpegSubsample = C.VipsForeignSubsample(params.SubsampleMode)
 
 	return vipsSaveToBuffer(p)
 }

--- a/vips/foreign.h
+++ b/vips/foreign.h
@@ -84,7 +84,7 @@ typedef struct SaveParams {
 
   // JPEG
   BOOL jpegOptimizeCoding;
-  VipsForeignJpegSubsample jpegSubsample;
+  VipsForeignSubsample jpegSubsample;
   BOOL jpegTrellisQuant;
   BOOL jpegOvershootDeringing;
   BOOL jpegOptimizeScans;


### PR DESCRIPTION
This removes the usage of the deprecated `VipsForeignJpegSubsample` enum, instead using the [VipsForeignSubsample](https://www.libvips.org/API/current/VipsForeignSave.html#VipsForeignSubsample) enum in it's place.

I have very limited understanding about C, header files and CGo, so apologies if this implementation is way off the mark. 

Closes #453 