### PR TITLE
Jemalloc option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ This will reduce GLib memory appetites by reducing the number of malloc arenas
 that it can create. By default GLib creates one are per thread, and this would
 follow to memory fragmentation.
 
+### Jemalloc
+If the arena option doesn't help, you can try replacing the standard allocator with `jemalloc`,
+which emphasizes fragmentation avoidance and scalable concurrency support.
+
+To do this, you need to install the `libjemalloc-dev` package. 
+And pass the following flags for build command:
+
+```
+CGO_CFLAGS="-fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free" CGO_LDFLAGS="-ljemalloc" go build
+```
+
+
 ## Contributing
 
 Feel free to file issues or create pull requests. See this [guide on contributing](https://github.com/davidbyttow/govips/blob/master/CONTRIBUTING.md) for more information.


### PR DESCRIPTION
## Issue

I ran into a problem with constantly growing `RSS` usage, when processing thousands of images sequentially. I used the `MALLOC_ARENA_MAX` environment variable, which improved the situation, but after the end of the image processing phase (in my application), a large chunk of memory was left by the process ~1.5GB. I started to investigate why this was happening and came to the conclusion that `MALLOC_ARENA_MAX` does not completely eliminate memory fragmentation. So I decided to replace the standard allocator in `libvips`, with `jemalloc`, which is made for such use cases. As a result, this completely fixed the situation, and minimized `RSS` usage as much as possible (as if `libvips` had never been used).

## Solution

I think it would be useful to add such a feature to the description so that people don't waste their time researching such problems.