### PR TITLE
Add access options while loading image

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -29,50 +29,50 @@ int load_image_buffer(LoadParams *params, void *buf, size_t len,
     // shrink: int, fail: bool, autorotate: bool
     code = vips_jpegload_buffer(buf, len, out, "fail", params->fail,
                                 "autorotate", params->autorotate, "shrink",
-                                params->jpegShrink, NULL);
+                                params->jpegShrink, "access", params->access, NULL);
   } else if (imageType == PNG) {
-    code = vips_pngload_buffer(buf, len, out, NULL);
+    code = vips_pngload_buffer(buf, len, out, "access", params->access, NULL);
   } else if (imageType == WEBP) {
     // page: int, n: int, scale: double
     code = vips_webpload_buffer(buf, len, out, "page", params->page, "n",
-                                params->n, NULL);
+                                params->n, "access", params->access, NULL);
   } else if (imageType == TIFF) {
     // page: int, n: int, autorotate: bool, subifd: int
     code =
         vips_tiffload_buffer(buf, len, out, "page", params->page, "n",
-                             params->n, "autorotate", params->autorotate, NULL);
+                             params->n, "autorotate", params->autorotate, "access", params->access, NULL);
   } else if (imageType == GIF) {
     // page: int, n: int, scale: double
     code = vips_gifload_buffer(buf, len, out, "page", params->page, "n",
-                               params->n, NULL);
+                               params->n, "access", params->access, NULL);
   } else if (imageType == PDF) {
     // page: int, n: int, dpi: double, scale: double, background: color
     code = vips_pdfload_buffer(buf, len, out, "page", params->page, "n",
-                               params->n, "dpi", params->dpi, NULL);
+                               params->n, "dpi", params->dpi, "access", params->access, NULL);
   } else if (imageType == SVG) {
     // dpi: double, scale: double, unlimited: bool
     code = vips_svgload_buffer(buf, len, out, "dpi", params->dpi, "unlimited",
-                               params->svgUnlimited, NULL);
+                               params->svgUnlimited, "access", params->access, NULL);
   } else if (imageType == HEIF) {
     // added autorotate on load as currently it addresses orientation issues
     // https://github.com/libvips/libvips/pull/1680
     // page: int, n: int, thumbnail: bool
     code = vips_heifload_buffer(buf, len, out, "page", params->page, "n",
                                 params->n, "thumbnail", params->heifThumbnail,
-                                "autorotate", TRUE, NULL);
+                                "autorotate", TRUE, "access", params->access, NULL);
   } else if (imageType == MAGICK) {
     // page: int, n: int, density: string
     code = vips_magickload_buffer(buf, len, out, "page", params->page, "n",
-                                  params->n, NULL);
+                                  params->n, "access", params->access, NULL);
   } else if (imageType == AVIF) {
     code = vips_heifload_buffer(buf, len, out, "page", params->page, "n",
                                 params->n, "thumbnail", params->heifThumbnail,
-                                "autorotate", params->autorotate, NULL);
+                                "autorotate", params->autorotate, "access", params->access, NULL);
 
   }
   #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 11)
   else if (imageType == JP2K) {
-       code = vips_jp2kload_buffer(buf, len, out, "page", params->page, NULL);
+       code = vips_jp2kload_buffer(buf, len, out, "page", params->page, "access", params->access, NULL);
   }
   #endif
 
@@ -100,17 +100,20 @@ int set_jpegload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_BOOL(operation, params->autorotate, "autorotate");
   MAYBE_SET_BOOL(operation, params->fail, "fail");
   MAYBE_SET_INT(operation, params->jpegShrink, "shrink");
+  MAYBE_SET_INT(operation, params->access, "access");
   return 0;
 }
 
 int set_pngload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_BOOL(operation, params->fail, "fail");
+  MAYBE_SET_INT(operation, params->access, "access");
   return 0;
 }
 
 int set_webpload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_INT(operation, params->page, "page");
   MAYBE_SET_INT(operation, params->n, "n");
+  MAYBE_SET_INT(operation, params->access, "access");
   return 0;
 }
 
@@ -118,12 +121,14 @@ int set_tiffload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_BOOL(operation, params->autorotate, "autorotate");
   MAYBE_SET_INT(operation, params->page, "page");
   MAYBE_SET_INT(operation, params->n, "n");
+  MAYBE_SET_INT(operation, params->access, "access");
   return 0;
 }
 
 int set_gifload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_INT(operation, params->page, "page");
   MAYBE_SET_INT(operation, params->n, "n");
+  MAYBE_SET_INT(operation, params->access, "access");
   return 0;
 }
 
@@ -131,12 +136,14 @@ int set_pdfload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_INT(operation, params->page, "page");
   MAYBE_SET_INT(operation, params->n, "n");
   MAYBE_SET_DOUBLE(operation, params->dpi, "dpi");
+  MAYBE_SET_INT(operation, params->access, "access");
   return 0;
 }
 
 int set_svgload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_BOOL(operation, params->svgUnlimited, "unlimited");
   MAYBE_SET_DOUBLE(operation, params->dpi, "dpi");
+  MAYBE_SET_INT(operation, params->access, "access");
   return 0;
 }
 
@@ -145,11 +152,13 @@ int set_heifload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_BOOL(operation, params->heifThumbnail, "thumbnail");
   MAYBE_SET_INT(operation, params->page, "page");
   MAYBE_SET_INT(operation, params->n, "n");
+  MAYBE_SET_INT(operation, params->access, "access");
   return 0;
 }
 
 int set_jp2kload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_INT(operation, params->page, "page");
+  MAYBE_SET_INT(operation, params->access, "access");
   return 0;
 }
 
@@ -161,6 +170,7 @@ int set_jxlload_options(VipsOperation *operation, LoadParams *params) {
 int set_magickload_options(VipsOperation *operation, LoadParams *params) {
   MAYBE_SET_INT(operation, params->page, "page");
   MAYBE_SET_INT(operation, params->n, "n");
+  MAYBE_SET_INT(operation, params->access, "access");
   return 0;
 }
 
@@ -509,6 +519,7 @@ LoadParams create_load_params(ImageType inputFormat) {
       .jpegShrink = defaultParam,
       .heifThumbnail = defaultParam,
       .svgUnlimited = defaultParam,
+      .access = defaultParam,
   };
   return p;
 }

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -117,6 +117,15 @@ const (
 	PngFilterAll   PngFilter = C.VIPS_FOREIGN_PNG_FILTER_ALL
 )
 
+// Access represents how libvips opens files.
+// See https://www.libvips.org/API/current/How-it-opens-files.html
+const (
+	AccessRandom               int = C.VIPS_ACCESS_RANDOM
+	AccessSequential           int = C.VIPS_ACCESS_SEQUENTIAL
+	AccessSequentialUnbuffered int = C.VIPS_ACCESS_SEQUENTIAL_UNBUFFERED
+	AccessLast                 int = C.VIPS_ACCESS_LAST
+)
+
 // FileExt returns the canonical extension for the ImageType
 func (i ImageType) FileExt() string {
 	if ext, ok := imageTypeExtensionMap[i]; ok {
@@ -322,6 +331,7 @@ func createImportParams(format ImageType, params *ImportParams) C.LoadParams {
 	maybeSetIntParam(params.JpegShrinkFactor, &p.jpegShrink)
 	maybeSetBoolParam(params.HeifThumbnail, &p.heifThumbnail)
 	maybeSetBoolParam(params.SvgUnlimited, &p.svgUnlimited)
+	maybeSetIntParam(params.Access, &p.access)
 
 	if params.Density.IsSet() {
 		C.set_double_param(&p.dpi, C.gdouble(params.Density.Get()))

--- a/vips/foreign.h
+++ b/vips/foreign.h
@@ -66,6 +66,7 @@ typedef struct LoadParams {
   Param jpegShrink;
   Param heifThumbnail;
   Param svgUnlimited;
+  Param access;
 
 } LoadParams;
 

--- a/vips/image.go
+++ b/vips/image.go
@@ -113,6 +113,7 @@ type ImportParams struct {
 	JpegShrinkFactor IntParameter
 	HeifThumbnail    BoolParameter
 	SvgUnlimited     BoolParameter
+	Access           IntParameter
 }
 
 // NewImportParams creates default ImportParams
@@ -148,6 +149,9 @@ func (i *ImportParams) OptionString() string {
 	}
 	if v := i.HeifThumbnail; v.IsSet() {
 		values = append(values, "thumbnail="+boolToStr(v.Get()))
+	}
+	if v := i.Access; v.IsSet() {
+		values = append(values, "access="+strconv.Itoa(v.Get()))
 	}
 	return strings.Join(values, ",")
 }

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -1256,6 +1256,28 @@ func Test_MakeTextImage(t *testing.T) {
 	require.NotNil(t, pangoTextImage)
 }
 
+func Test_LoadImageWithAccessMode(t *testing.T) {
+	Startup(nil)
+
+	param := NewImportParams()
+	param.Access.Set(AccessSequential)
+	jpegImg, err := LoadImageFromFile(resources+"jpg-24bit.jpg", param)
+	require.NoError(t, err)
+	assert.NotNil(t, jpegImg)
+
+	pngImg, err := LoadImageFromFile(resources+"png-24bit.png", param)
+	require.NoError(t, err)
+	assert.NotNil(t, pngImg)
+
+	webpImg, err := LoadImageFromFile(resources+"webp+alpha.webp", param)
+	require.NoError(t, err)
+	assert.NotNil(t, webpImg)
+
+	gifImg, err := LoadImageFromFile(resources+"gif-animated.gif", param)
+	require.NoError(t, err)
+	assert.NotNil(t, gifImg)
+}
+
 // TODO unit tests to cover:
 // NewImageFromReader failing test
 // NewImageFromFile failing test


### PR DESCRIPTION
Hello again.

### PR Description 
This PR adds access mode options when loading an image. Since libvips supports access modes as described in the [API Document](https://www.libvips.org/API/current/VipsImage.html#vips-image-new-from-file), Go Vips needs an interface for it.
There was a similar issue (e.g., #197), but it has not been applied yet.
To address this, the Access field has been added to the ImportParams struct.