### PR TITLE
Add Magick Save, Support ICO LOAD

### DIFF
--- a/vips/foreign.h
+++ b/vips/foreign.h
@@ -135,6 +135,12 @@ typedef struct SaveParams {
   double jxlDistance;
   int jxlEffort;
   BOOL jxlLossless;
+
+  // MAGICK
+  char *magickFormat;
+  BOOL magickOptimizeGifFrames;
+  BOOL magickOptimizeGifTransparency;
+  int magickBitDepth;
 } SaveParams;
 
 SaveParams create_save_params(ImageType outputFormat);

--- a/vips/image.go
+++ b/vips/image.go
@@ -428,6 +428,22 @@ func NewJxlExportParams() *JxlExportParams {
 	}
 }
 
+// MagickExportParams are options when exporting an image to file or buffer by ImageMagick.
+type MagickExportParams struct {
+	Quality                 int
+	Format                  string
+	OptimizeGifFrames       bool
+	OptimizeGifTransparency bool
+	BitDepth                int
+}
+
+// NewMagickExportParams creates default values for an export of an image by ImageMagick.
+func NewMagickExportParams() *MagickExportParams {
+	return &MagickExportParams{
+		Quality: 75,
+	}
+}
+
 // NewImageFromReader loads an ImageRef from the given reader
 func NewImageFromReader(r io.Reader) (*ImageRef, error) {
 	buf, err := io.ReadAll(r)
@@ -1077,6 +1093,21 @@ func (r *ImageRef) ExportJxl(params *JxlExportParams) ([]byte, *ImageMetadata, e
 	}
 
 	return buf, r.newMetadata(ImageTypeJXL), nil
+}
+
+// ExportMagick exports the image as Format set in param to a buffer.
+func (r *ImageRef) ExportMagick(params *MagickExportParams) ([]byte, *ImageMetadata, error) {
+	if params == nil {
+		params = NewMagickExportParams()
+		params.Format = "JPG"
+	}
+
+	buf, err := vipsSaveMagickToBuffer(r.image, *params)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return buf, r.newMetadata(ImageTypeMagick), nil
 }
 
 // CompositeMulti composites the given overlay image on top of the associated image with provided blending mode.

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -1278,6 +1278,39 @@ func Test_LoadImageWithAccessMode(t *testing.T) {
 	assert.NotNil(t, gifImg)
 }
 
+func Test_SaveImageWithMagick(t *testing.T) {
+	Startup(nil)
+
+	// GIF Save With Magick
+	param := NewImportParams()
+	gifImage, err := LoadImageFromFile(resources+"gif-animated.gif", param)
+	require.NoError(t, err)
+	require.NotNil(t, gifImage)
+
+	exportParam := NewMagickExportParams()
+	exportParam.Format = "GIF"
+	exportParam.BitDepth = 8
+
+	gifBuf, _, err := gifImage.ExportMagick(exportParam)
+	require.NoError(t, err)
+	require.NotNil(t, gifBuf)
+	require.True(t, isGIF(gifBuf))
+
+	// BMP Save With Magick
+	param = NewImportParams()
+	bmpImage, err := LoadImageFromFile(resources+"koala.bmp", param)
+	require.NoError(t, err)
+	require.NotNil(t, bmpImage)
+
+	exportParam = NewMagickExportParams()
+	exportParam.Format = "BMP"
+
+	bmpBuf, _, err := bmpImage.ExportMagick(exportParam)
+	require.NoError(t, err)
+	require.NotNil(t, bmpBuf)
+	require.True(t, isBMP(bmpBuf))
+}
+
 // TODO unit tests to cover:
 // NewImageFromReader failing test
 // NewImageFromFile failing test


### PR DESCRIPTION
### PR Description 
This PR adds ExportMagick(). libvips supports image encoding through ImageMagick, and formats such as BMP require ImageMagick for proper saving. ([vips_magicksave](https://www.libvips.org/API/8.16/VipsForeignSave.html#vips-magicksave))
Additionally, ICO image loading can now be handled with ImageMagick.

### Added
func (r *ImageRef) ExportMagick(params *MagickExportParams) ([]byte, *ImageMetadata, error): Exports an image using ImageMagick.
MagickExportParams: Parameters for configuring ImageMagick-based export.

### Modified 
Previously, when saving GIFs, govips used magicksave if the libvips version was lower than 8.12. Therefore, this PR modified the GIF save logic accordingly to accommodate the changes in magick save options in this changes.