### PR TITLE
add keep option when export image

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -262,9 +262,11 @@ int set_jpegsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+  if (!ret && params->keep >= VIPS_FOREIGN_KEEP_NONE) {
     ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
-  #endif
+  }
+#endif
 
   return ret;
 }
@@ -289,9 +291,13 @@ int set_pngsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "bitdepth", params->pngBitdepth, NULL);
   }
 
-  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+
+
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+  if (!ret && params->keep >= VIPS_FOREIGN_KEEP_NONE) {
     ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
-  #endif
+  }
+#endif
 
   // TODO: Handle `profile` param.
 
@@ -317,9 +323,11 @@ int set_webpsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+  if (!ret && params->keep >= VIPS_FOREIGN_KEEP_NONE) {
     ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
-  #endif
+  }
+#endif
 
   return ret;
 }
@@ -336,9 +344,11 @@ int set_tiffsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+  if (!ret && params->keep >= VIPS_FOREIGN_KEEP_NONE) {
     ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
-  #endif
+  }
+#endif
 
   return ret;
 }
@@ -355,9 +365,11 @@ int set_magicksave_options(VipsOperation *operation, SaveParams *params) {
                           NULL);
   }
 
-  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+  if (!ret && params->keep >= VIPS_FOREIGN_KEEP_NONE) {
     ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
-  #endif
+  }
+#endif
 
   return ret;
 }
@@ -376,9 +388,11 @@ int set_gifsave_options(VipsOperation *operation, SaveParams *params) {
       ret = vips_object_set(VIPS_OBJECT(operation), "bitdepth", params->gifBitdepth, NULL);
   }
 
-  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+  if (!ret && params->keep >= VIPS_FOREIGN_KEEP_NONE) {
     ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
-  #endif
+  }
+#endif
 
   return ret;
 }
@@ -405,9 +419,11 @@ int set_heifsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+  if (!ret && params->keep >= VIPS_FOREIGN_KEEP_NONE) {
     ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
-  #endif
+  }
+#endif
 
   return ret;
 }
@@ -435,9 +451,11 @@ int set_avifsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+  if (!ret && params->keep >= VIPS_FOREIGN_KEEP_NONE) {
     ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
-  #endif
+  }
+#endif
 
   return ret;
 }
@@ -452,9 +470,11 @@ int set_jp2ksave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+  if (!ret && params->keep >= VIPS_FOREIGN_KEEP_NONE) {
     ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
-  #endif
+  }
+#endif
 
   return ret;
 }
@@ -469,9 +489,11 @@ int set_jxlsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
-  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+#if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+  if (!ret && params->keep >= VIPS_FOREIGN_KEEP_NONE) {
     ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
-  #endif
+  }
+#endif
 
   return ret;
 }

--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -262,6 +262,10 @@ int set_jpegsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
+  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+    ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
+  #endif
+
   return ret;
 }
 
@@ -284,6 +288,10 @@ int set_pngsave_options(VipsOperation *operation, SaveParams *params) {
   if (!ret && params->pngBitdepth) {
     ret = vips_object_set(VIPS_OBJECT(operation), "bitdepth", params->pngBitdepth, NULL);
   }
+
+  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+    ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
+  #endif
 
   // TODO: Handle `profile` param.
 
@@ -309,6 +317,10 @@ int set_webpsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
+  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+    ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
+  #endif
+
   return ret;
 }
 
@@ -324,6 +336,10 @@ int set_tiffsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
+  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+    ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
+  #endif
+
   return ret;
 }
 
@@ -338,6 +354,11 @@ int set_magicksave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "quality", params->quality,
                           NULL);
   }
+
+  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+    ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
+  #endif
+
   return ret;
 }
 
@@ -354,6 +375,11 @@ int set_gifsave_options(VipsOperation *operation, SaveParams *params) {
   if (params->gifBitdepth >= 1 && params->gifBitdepth <= 8) {
       ret = vips_object_set(VIPS_OBJECT(operation), "bitdepth", params->gifBitdepth, NULL);
   }
+
+  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+    ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
+  #endif
+
   return ret;
 }
 
@@ -378,6 +404,10 @@ int set_heifsave_options(VipsOperation *operation, SaveParams *params) {
   if (!ret && params->quality) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
+
+  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+    ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
+  #endif
 
   return ret;
 }
@@ -405,6 +435,10 @@ int set_avifsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
+  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+    ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
+  #endif
+
   return ret;
 }
 
@@ -418,6 +452,10 @@ int set_jp2ksave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
+  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+    ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
+  #endif
+
   return ret;
 }
 
@@ -430,6 +468,10 @@ int set_jxlsave_options(VipsOperation *operation, SaveParams *params) {
   if (!ret && params->quality) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
+
+  #if (VIPS_MAJOR_VERSION >= 8) && (VIPS_MINOR_VERSION >= 15)
+    ret = vips_object_set(VIPS_OBJECT(operation), "keep", params->keep, NULL);
+  #endif
 
   return ret;
 }
@@ -545,6 +587,7 @@ static SaveParams defaultSaveParams = {
     .interlace = FALSE,
     .quality = 0,
     .stripMetadata = FALSE,
+    .keep = VIPS_FOREIGN_KEEP_ALL,
 
     .jpegOptimizeCoding = FALSE,
     .jpegSubsample = VIPS_FOREIGN_SUBSAMPLE_ON,

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -25,6 +25,19 @@ const (
 	VipsForeignSubsampleLast SubsampleMode = C.VIPS_FOREIGN_SUBSAMPLE_LAST
 )
 
+// ForeignKeep correlates to a libvips VipsForeignKeep
+type ForeignKeep int
+
+const (
+	VipsForeignKeepNone  ForeignKeep = C.VIPS_FOREIGN_KEEP_NONE
+	VipsForeignKeepExif  ForeignKeep = C.VIPS_FOREIGN_KEEP_EXIF
+	VipsForeignKeepXmp   ForeignKeep = C.VIPS_FOREIGN_KEEP_XMP
+	VipsForeignKeepIptc  ForeignKeep = C.VIPS_FOREIGN_KEEP_IPTC
+	VipsForeignKeepIcc   ForeignKeep = C.VIPS_FOREIGN_KEEP_ICC
+	VipsForeignKeepOther ForeignKeep = C.VIPS_FOREIGN_KEEP_OTHER
+	VipsForeignKeepAll   ForeignKeep = C.VIPS_FOREIGN_KEEP_ALL
+)
+
 // ImageType represents an image type
 type ImageType int
 
@@ -354,6 +367,7 @@ func vipsSaveJPEGToBuffer(in *C.VipsImage, params JpegExportParams) ([]byte, err
 	p := C.create_save_params(C.JPEG)
 	p.inputImage = in
 	p.stripMetadata = C.int(boolToInt(params.StripMetadata))
+	p.keep = C.VipsForeignKeep(params.Keep)
 	p.quality = C.int(params.Quality)
 	p.interlace = C.int(boolToInt(params.Interlace))
 	p.jpegOptimizeCoding = C.int(boolToInt(params.OptimizeCoding))
@@ -373,6 +387,7 @@ func vipsSavePNGToBuffer(in *C.VipsImage, params PngExportParams) ([]byte, error
 	p.inputImage = in
 	p.quality = C.int(params.Quality)
 	p.stripMetadata = C.int(boolToInt(params.StripMetadata))
+	p.keep = C.VipsForeignKeep(params.Keep)
 	p.interlace = C.int(boolToInt(params.Interlace))
 	p.pngCompression = C.int(params.Compression)
 	p.pngFilter = C.VipsForeignPngFilter(params.Filter)
@@ -389,6 +404,7 @@ func vipsSaveWebPToBuffer(in *C.VipsImage, params WebpExportParams) ([]byte, err
 	p := C.create_save_params(C.WEBP)
 	p.inputImage = in
 	p.stripMetadata = C.int(boolToInt(params.StripMetadata))
+	p.keep = C.VipsForeignKeep(params.Keep)
 	p.quality = C.int(params.Quality)
 	p.webpLossless = C.int(boolToInt(params.Lossless))
 	p.webpNearLossless = C.int(boolToInt(params.NearLossless))
@@ -411,6 +427,7 @@ func vipsSaveTIFFToBuffer(in *C.VipsImage, params TiffExportParams) ([]byte, err
 	p := C.create_save_params(C.TIFF)
 	p.inputImage = in
 	p.stripMetadata = C.int(boolToInt(params.StripMetadata))
+	p.keep = C.VipsForeignKeep(params.Keep)
 	p.quality = C.int(params.Quality)
 	p.tiffCompression = C.VipsForeignTiffCompression(params.Compression)
 	p.tiffPyramid = C.int(boolToInt(params.Pyramid))
@@ -431,6 +448,7 @@ func vipsSaveHEIFToBuffer(in *C.VipsImage, params HeifExportParams) ([]byte, err
 	p.heifLossless = C.int(boolToInt(params.Lossless))
 	p.heifBitdepth = C.int(params.Bitdepth)
 	p.heifEffort = C.int(params.Effort)
+	p.keep = C.VipsForeignKeep(params.Keep)
 
 	return vipsSaveToBuffer(p)
 }
@@ -452,6 +470,7 @@ func vipsSaveAVIFToBuffer(in *C.VipsImage, params AvifExportParams) ([]byte, err
 	p.heifLossless = C.int(boolToInt(params.Lossless))
 	p.heifBitdepth = C.int(params.Bitdepth)
 	p.heifEffort = C.int(effort)
+	p.keep = C.VipsForeignKeep(params.Keep)
 
 	return vipsSaveToBuffer(p)
 }
@@ -467,6 +486,7 @@ func vipsSaveJP2KToBuffer(in *C.VipsImage, params Jp2kExportParams) ([]byte, err
 	p.jp2kTileWidth = C.int(params.TileWidth)
 	p.jp2kTileHeight = C.int(params.TileHeight)
 	p.jpegSubsample = C.VipsForeignSubsample(params.SubsampleMode)
+	p.keep = C.VipsForeignKeep(params.Keep)
 
 	return vipsSaveToBuffer(p)
 }
@@ -480,6 +500,7 @@ func vipsSaveGIFToBuffer(in *C.VipsImage, params GifExportParams) ([]byte, error
 	p.gifDither = C.double(params.Dither)
 	p.gifEffort = C.int(params.Effort)
 	p.gifBitdepth = C.int(params.Bitdepth)
+	p.keep = C.VipsForeignKeep(params.Keep)
 
 	return vipsSaveToBuffer(p)
 }
@@ -495,6 +516,7 @@ func vipsSaveJxlToBuffer(in *C.VipsImage, params JxlExportParams) ([]byte, error
 	p.jxlTier = C.int(params.Tier)
 	p.jxlDistance = C.double(params.Distance)
 	p.jxlEffort = C.int(params.Effort)
+	p.keep = C.VipsForeignKeep(params.Keep)
 
 	return vipsSaveToBuffer(p)
 }
@@ -513,6 +535,7 @@ func vipsSaveMagickToBuffer(in *C.VipsImage, params MagickExportParams) ([]byte,
 	p.magickOptimizeGifFrames = C.int(boolToInt(params.OptimizeGifFrames))
 	p.magickOptimizeGifTransparency = C.int(boolToInt(params.OptimizeGifTransparency))
 	p.magickBitDepth = C.int(params.BitDepth)
+	p.keep = C.VipsForeignKeep(params.Keep)
 
 	return vipsSaveToBuffer(p)
 }

--- a/vips/foreign.h
+++ b/vips/foreign.h
@@ -80,6 +80,7 @@ typedef struct SaveParams {
   size_t outputLen;
 
   BOOL stripMetadata;
+  VipsForeignKeep keep;
   int quality;
   BOOL interlace;
 

--- a/vips/image.go
+++ b/vips/image.go
@@ -173,6 +173,7 @@ type ExportParams struct {
 	Lossless           bool
 	Effort             int
 	StripMetadata      bool
+	Keep               ForeignKeep
 	OptimizeCoding     bool          // jpeg param
 	SubsampleMode      SubsampleMode // jpeg param
 	TrellisQuant       bool          // jpeg param
@@ -195,6 +196,7 @@ func NewDefaultExportParams() *ExportParams {
 		Interlaced:  true,
 		Lossless:    false,
 		Effort:      4,
+		Keep:        VipsForeignKeepAll,
 	}
 }
 
@@ -206,6 +208,7 @@ func NewDefaultJPEGExportParams() *ExportParams {
 		Format:     ImageTypeJPEG,
 		Quality:    80,
 		Interlaced: true,
+		Keep:       VipsForeignKeepAll,
 	}
 }
 
@@ -217,6 +220,7 @@ func NewDefaultPNGExportParams() *ExportParams {
 		Format:      ImageTypePNG,
 		Compression: 6,
 		Interlaced:  false,
+		Keep:        VipsForeignKeepAll,
 	}
 }
 
@@ -229,6 +233,7 @@ func NewDefaultWEBPExportParams() *ExportParams {
 		Quality:  75,
 		Lossless: false,
 		Effort:   4,
+		Keep:     VipsForeignKeepAll,
 	}
 }
 
@@ -243,6 +248,7 @@ type JpegExportParams struct {
 	OvershootDeringing bool
 	OptimizeScans      bool
 	QuantTable         int
+	Keep               ForeignKeep
 }
 
 // NewJpegExportParams creates default values for an export of a JPEG image.
@@ -251,6 +257,7 @@ func NewJpegExportParams() *JpegExportParams {
 	return &JpegExportParams{
 		Quality:   80,
 		Interlace: true,
+		Keep:      VipsForeignKeepAll,
 	}
 }
 
@@ -265,6 +272,7 @@ type PngExportParams struct {
 	Dither        float64
 	Bitdepth      int
 	Profile       string // TODO: Use this param during save
+	Keep          ForeignKeep
 }
 
 // NewPngExportParams creates default values for an export of a PNG image.
@@ -275,6 +283,7 @@ func NewPngExportParams() *PngExportParams {
 		Filter:      PngFilterNone,
 		Interlace:   false,
 		Palette:     false,
+		Keep:        VipsForeignKeepAll,
 	}
 }
 
@@ -291,6 +300,7 @@ type WebpExportParams struct {
 	MinSize         bool
 	MinKeyFrames    int
 	MaxKeyFrames    int
+	Keep            ForeignKeep
 }
 
 // NewWebpExportParams creates default values for an export of a WEBP image.
@@ -301,6 +311,7 @@ func NewWebpExportParams() *WebpExportParams {
 		Lossless:        false,
 		NearLossless:    false,
 		ReductionEffort: 4,
+		Keep:            VipsForeignKeepAll,
 	}
 }
 
@@ -314,6 +325,7 @@ type TiffExportParams struct {
 	Tile          bool
 	TileHeight    int
 	TileWidth     int
+	Keep          ForeignKeep
 }
 
 // NewTiffExportParams creates default values for an export of a TIFF image.
@@ -326,6 +338,7 @@ func NewTiffExportParams() *TiffExportParams {
 		Tile:        false,
 		TileHeight:  256,
 		TileWidth:   256,
+		Keep:        VipsForeignKeepAll,
 	}
 }
 
@@ -339,6 +352,7 @@ type GifExportParams struct {
 	Dither        float64
 	Effort        int
 	Bitdepth      int
+	Keep          ForeignKeep
 }
 
 // NewGifExportParams creates default values for an export of a GIF image.
@@ -347,6 +361,7 @@ func NewGifExportParams() *GifExportParams {
 		Quality:  75,
 		Effort:   7,
 		Bitdepth: 8,
+		Keep:     VipsForeignKeepAll,
 	}
 }
 
@@ -356,6 +371,7 @@ type HeifExportParams struct {
 	Bitdepth int
 	Effort   int
 	Lossless bool
+	Keep     ForeignKeep
 }
 
 // NewHeifExportParams creates default values for an export of a HEIF image.
@@ -365,6 +381,7 @@ func NewHeifExportParams() *HeifExportParams {
 		Bitdepth: 8,
 		Effort:   5,
 		Lossless: false,
+		Keep:     VipsForeignKeepAll,
 	}
 }
 
@@ -375,6 +392,7 @@ type AvifExportParams struct {
 	Bitdepth      int
 	Effort        int
 	Lossless      bool
+	Keep          ForeignKeep
 
 	// DEPRECATED - Use Effort instead.
 	Speed int
@@ -387,6 +405,7 @@ func NewAvifExportParams() *AvifExportParams {
 		Bitdepth: 8,
 		Effort:   5,
 		Lossless: false,
+		Keep:     VipsForeignKeepAll,
 	}
 }
 
@@ -397,6 +416,7 @@ type Jp2kExportParams struct {
 	TileWidth     int
 	TileHeight    int
 	SubsampleMode SubsampleMode
+	Keep          ForeignKeep
 }
 
 // NewJp2kExportParams creates default values for an export of an JPEG2000 image.
@@ -406,6 +426,7 @@ func NewJp2kExportParams() *Jp2kExportParams {
 		Lossless:   false,
 		TileWidth:  512,
 		TileHeight: 512,
+		Keep:       VipsForeignKeepAll,
 	}
 }
 
@@ -416,6 +437,7 @@ type JxlExportParams struct {
 	Tier     int
 	Distance float64
 	Effort   int
+	Keep     ForeignKeep
 }
 
 // NewJxlExportParams creates default values for an export of an JXL image.
@@ -425,6 +447,7 @@ func NewJxlExportParams() *JxlExportParams {
 		Lossless: false,
 		Effort:   7,
 		Distance: 1.0,
+		Keep:     VipsForeignKeepAll,
 	}
 }
 
@@ -435,12 +458,14 @@ type MagickExportParams struct {
 	OptimizeGifFrames       bool
 	OptimizeGifTransparency bool
 	BitDepth                int
+	Keep                    ForeignKeep
 }
 
 // NewMagickExportParams creates default values for an export of an image by ImageMagick.
 func NewMagickExportParams() *MagickExportParams {
 	return &MagickExportParams{
 		Quality: 75,
+		Keep:    VipsForeignKeepAll,
 	}
 }
 
@@ -882,6 +907,7 @@ func (r *ImageRef) Export(params *ExportParams) ([]byte, *ImageMetadata, error) 
 	case ImageTypeGIF:
 		return r.ExportGIF(&GifExportParams{
 			Quality: params.Quality,
+			Keep:    params.Keep,
 		})
 	case ImageTypeWEBP:
 		return r.ExportWebp(&WebpExportParams{
@@ -889,12 +915,14 @@ func (r *ImageRef) Export(params *ExportParams) ([]byte, *ImageMetadata, error) 
 			Quality:         params.Quality,
 			Lossless:        params.Lossless,
 			ReductionEffort: params.Effort,
+			Keep:            params.Keep,
 		})
 	case ImageTypePNG:
 		return r.ExportPng(&PngExportParams{
 			StripMetadata: params.StripMetadata,
 			Compression:   params.Compression,
 			Interlace:     params.Interlaced,
+			Keep:          params.Keep,
 		})
 	case ImageTypeTIFF:
 		compression := TiffCompressionLzw
@@ -905,11 +933,13 @@ func (r *ImageRef) Export(params *ExportParams) ([]byte, *ImageMetadata, error) 
 			StripMetadata: params.StripMetadata,
 			Quality:       params.Quality,
 			Compression:   compression,
+			Keep:          params.Keep,
 		})
 	case ImageTypeHEIF:
 		return r.ExportHeif(&HeifExportParams{
 			Quality:  params.Quality,
 			Lossless: params.Lossless,
+			Keep:     params.Keep,
 		})
 	case ImageTypeAVIF:
 		return r.ExportAvif(&AvifExportParams{
@@ -917,12 +947,14 @@ func (r *ImageRef) Export(params *ExportParams) ([]byte, *ImageMetadata, error) 
 			Quality:       params.Quality,
 			Lossless:      params.Lossless,
 			Speed:         params.Speed,
+			Keep:          params.Keep,
 		})
 	case ImageTypeJXL:
 		return r.ExportJxl(&JxlExportParams{
 			Quality:  params.Quality,
 			Lossless: params.Lossless,
 			Effort:   params.Effort,
+			Keep:     params.Keep,
 		})
 	default:
 		format = ImageTypeJPEG
@@ -936,6 +968,7 @@ func (r *ImageRef) Export(params *ExportParams) ([]byte, *ImageMetadata, error) 
 			OvershootDeringing: params.OvershootDeringing,
 			OptimizeScans:      params.OptimizeScans,
 			QuantTable:         params.QuantTable,
+			Keep:               params.Keep,
 		})
 	}
 }

--- a/vips/image_golden_test.go
+++ b/vips/image_golden_test.go
@@ -884,6 +884,7 @@ func TestImage_SubsampleMode(t *testing.T) {
 		exportJpeg(&JpegExportParams{
 			SubsampleMode: VipsForeignSubsampleOn,
 			StripMetadata: true,
+			Keep:          VipsForeignKeepNone,
 			Quality:       75,
 		}),
 	)
@@ -897,6 +898,7 @@ func TestImage_TrellisQuant(t *testing.T) {
 		exportJpeg(&JpegExportParams{
 			SubsampleMode: VipsForeignSubsampleAuto,
 			StripMetadata: true,
+			Keep:          VipsForeignKeepNone,
 			Quality:       75,
 			TrellisQuant:  true,
 		}),
@@ -911,6 +913,7 @@ func TestImage_OvershootDeringing(t *testing.T) {
 		exportJpeg(&JpegExportParams{
 			SubsampleMode:      VipsForeignSubsampleAuto,
 			StripMetadata:      true,
+			Keep:               VipsForeignKeepNone,
 			Quality:            75,
 			OvershootDeringing: true,
 		}),
@@ -925,6 +928,7 @@ func TestImage_OptimizeScans(t *testing.T) {
 		exportJpeg(&JpegExportParams{
 			SubsampleMode: VipsForeignSubsampleAuto,
 			StripMetadata: true,
+			Keep:          VipsForeignKeepNone,
 			Quality:       75,
 			Interlace:     true,
 			OptimizeScans: true,
@@ -940,6 +944,7 @@ func TestImage_QuantTable(t *testing.T) {
 		exportJpeg(&JpegExportParams{
 			SubsampleMode: VipsForeignSubsampleAuto,
 			StripMetadata: true,
+			Keep:          VipsForeignKeepNone,
 			Quality:       75,
 			QuantTable:    3,
 		}),

--- a/vips/image_golden_test.go
+++ b/vips/image_golden_test.go
@@ -967,6 +967,15 @@ func TestPDF_WithOffsetStart(t *testing.T) {
 		}, nil)
 }
 
+func TestImage_KeepMetadata(t *testing.T) {
+	param := NewPngExportParams()
+	param.Keep = VipsForeignKeepXmp | VipsForeignKeepIptc | VipsForeignKeepExif
+	goldenTest(t, resources+"has-icc-profile.png",
+		nil, func(result *ImageRef) {
+			assert.True(t, !result.HasICCProfile(), "should have no ICC profile")
+		}, exportPng(param))
+}
+
 func testWebpOptimizeIccProfile(t *testing.T, exportParams *WebpExportParams) []byte {
 	return goldenTest(t, resources+"has-icc-profile.png",
 		func(img *ImageRef) error {


### PR DESCRIPTION
### PR Description 
This PR adds keep option to  Export Params. Since libvips version 8.15, the strip option has been deprecated. Therefore, for versions 8.15 and above, the keep option must be provided. However, for versions below 8.15, the strip option should be maintained for compatibility. To handle this, an #ifdef macro is used to apply the keep option only for libvips 8.15 and above.