### PR TITLE
Add new HEIC magic numbers for 10 bit images

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -227,12 +227,18 @@ func isWEBP(buf []byte) bool {
 // https://github.com/strukturag/libheif/blob/master/libheif/heif.cc
 var ftyp = []byte("ftyp")
 var heic = []byte("heic")
+var heix = []byte("heix")
+var heim = []byte("heim")
+var heis = []byte("heis")
 var mif1 = []byte("mif1")
 var msf1 = []byte("msf1")
 var avif = []byte("avif")
 
 func isHEIF(buf []byte) bool {
 	return bytes.Equal(buf[4:8], ftyp) && (bytes.Equal(buf[8:12], heic) ||
+		bytes.Equal(buf[8:12], heix) ||
+		bytes.Equal(buf[8:12], heim) ||
+		bytes.Equal(buf[8:12], heis) ||
 		bytes.Equal(buf[8:12], mif1) ||
 		bytes.Equal(buf[8:12], msf1)) ||
 		isAVIF(buf)


### PR DESCRIPTION
Hey everyone, we know that this project is in a maintenance state, but we lack the resources to migrate to the recommended `vipsgen` library and we need to make `govips` work with 10 bit HEIC images from Apple devices, which have a different magic number, see here:
https://github.com/strukturag/libheif/issues/83#issuecomment-421427091

Since they are supported by libheif it should be a no-brainer to add them:
https://github.com/strukturag/libheif/blob/master/go/heif/heif.go#L1508-L1517

It was tested internally with a 10 bit image successfully.