### PR TITLE
Fix CMYK ICC profile ignored when embedded profile exists

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -2238,7 +2238,9 @@ func (r *ImageRef) ToBytes() ([]byte, error) {
 
 func (r *ImageRef) determineInputICCProfile() (inputProfile string) {
 	if r.Interpretation() == InterpretationCMYK {
-		inputProfile = "cmyk"
+		if !r.HasICCProfile() {
+			inputProfile = "cmyk"
+		}
 	}
 	return
 }


### PR DESCRIPTION
## Summary
- Fixes #275
- `determineInputICCProfile()` was unconditionally returning `"cmyk"` for CMYK images, overriding any embedded ICC profile
- Now only falls back to the generic `"cmyk"` profile when no embedded ICC profile is present, so `OptimizeICCProfile()` correctly uses the actual embedded profile

## Test plan
- [ ] Run existing `OptimizeICCProfile_CMYK` test to verify no regression
- [ ] Verify CMYK images with embedded ICC profiles preserve correct colors after `OptimizeICCProfile()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Respect embedded ICC profiles by setting `vips.ImageRef.determineInputICCProfile` to return empty inputProfile for CMYK images with an embedded profile in [vips/image.go](https://github.com/davidbyttow/govips/pull/497/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b)
> Adjust `vips.ImageRef.determineInputICCProfile` so CMYK images only set inputProfile to `"cmyk"` when no embedded ICC profile is present.
>
> #### 📍Where to Start
> Start with the `determineInputICCProfile` method in [vips/image.go](https://github.com/davidbyttow/govips/pull/497/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 664e883.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->