### PR TITLE
Fix TIFF tile dimensions zero-value crash

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -436,8 +436,16 @@ func vipsSaveTIFFToBuffer(in *C.VipsImage, params TiffExportParams) ([]byte, err
 	p.tiffCompression = C.VipsForeignTiffCompression(params.Compression)
 	p.tiffPyramid = C.int(boolToInt(params.Pyramid))
 	p.tiffTile = C.int(boolToInt(params.Tile))
-	p.tiffTileHeight = C.int(params.TileHeight)
-	p.tiffTileWidth = C.int(params.TileWidth)
+	tileHeight := params.TileHeight
+	tileWidth := params.TileWidth
+	if tileHeight <= 0 {
+		tileHeight = 256
+	}
+	if tileWidth <= 0 {
+		tileWidth = 256
+	}
+	p.tiffTileHeight = C.int(tileHeight)
+	p.tiffTileWidth = C.int(tileWidth)
 
 	return vipsSaveToBuffer(p)
 }


### PR DESCRIPTION
## Summary
- Fixes #463
- Zero-value `TileWidth`/`TileHeight` passed to libvips causes a GLib-CRITICAL assertion failure
- Now defaults tile dimensions to 256 (matching `NewTiffExportParams` defaults) when zero or negative values are provided

## Test plan
- [ ] Verify TIFF export with default `TiffExportParams{}` (zero-value struct) no longer causes GLib-CRITICAL
- [ ] Verify existing TIFF export tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent TIFF save crash by defaulting non-positive tile dimensions to 256 in `vips.vipsSaveTIFFToBuffer` in [foreign.go](https://github.com/davidbyttow/govips/pull/498/files#diff-ec94a2793e4149e5e3c5e926e52086a17d586f71fe03e67405c96512de0d6181)
> Add validation in `vips.vipsSaveTIFFToBuffer` to set `p.tiffTileHeight` and `p.tiffTileWidth` to 256 when `TiffExportParams.TileHeight` or `TileWidth` are <= 0 in [foreign.go](https://github.com/davidbyttow/govips/pull/498/files#diff-ec94a2793e4149e5e3c5e926e52086a17d586f71fe03e67405c96512de0d6181).
>
> #### 📍Where to Start
> Start with the `vips.vipsSaveTIFFToBuffer` save helper in [foreign.go](https://github.com/davidbyttow/govips/pull/498/files#diff-ec94a2793e4149e5e3c5e926e52086a17d586f71fe03e67405c96512de0d6181).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef607b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->