### PR TITLE
Fix JXL type detection for ISOBMFF containers

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -293,7 +293,13 @@ var jxlHeader = []byte("\xff\x0a")
 var jxlHeaderISOBMFF = []byte("\x00\x00\x00\x0C\x4A\x58\x4C\x20\x0D\x0A\x87\x0A")
 
 func isJXL(buf []byte) bool {
-	return bytes.HasPrefix(buf, jxlHeader) || bytes.HasPrefix(buf, jxlHeaderISOBMFF)
+	if len(buf) >= 2 && buf[0] == 0xFF && buf[1] == 0x0A {
+		return true
+	}
+	if len(buf) >= 8 && bytes.Equal(buf[4:8], []byte("JXL ")) {
+		return true
+	}
+	return false
 }
 
 var icoHeader = []byte("\x00\x00\x01\x00")


### PR DESCRIPTION
## Summary
- Fixes #457
- `DetermineImageType` returned `ImageTypeUnknown` for some valid JXL files because the ISOBMFF container format has a variable-length box size in bytes 0-3
- Now checks for the constant `"JXL "` type code at bytes 4-7 instead of requiring an exact 12-byte prefix match, while still detecting naked codestream format via the `0xFF 0x0A` prefix

## Test plan
- [ ] Verify JXL files with standard 12-byte ISOBMFF header still detected
- [ ] Verify JXL files with non-standard box sizes are now correctly detected
- [ ] Verify naked JXL codestream files still detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix JXL type detection in `vips.isJXL` to accept 0xFF 0x0A at bytes 0–1 or "JXL " at bytes 4–7 for ISOBMFF containers
> Replace prefix checks with explicit signature tests and length guards in [foreign.go](https://github.com/davidbyttow/govips/pull/499/files#diff-ec94a2793e4149e5e3c5e926e52086a17d586f71fe03e67405c96512de0d6181), matching `0xFF,0x0A` at start or "JXL " at offset 4.
>
> #### 📍Where to Start
> Start with the `isJXL` utility in [foreign.go](https://github.com/davidbyttow/govips/pull/499/files#diff-ec94a2793e4149e5e3c5e926e52086a17d586f71fe03e67405c96512de0d6181).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0d796f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->