### PR TITLE
Document GIF quality param limitation with native gifsave

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -331,16 +331,24 @@ func NewTiffExportParams() *TiffExportParams {
 	}
 }
 
-// GifExportParams are options when exporting a GIF to file or buffer
-// Please note that if vips version is above 8.12, then `vips_gifsave_buffer` is used, and only `Dither`, `Effort`, `Bitdepth` is used.
-// If vips version is below 8.12, then `vips_magicksave_buffer` is used, and only `Bitdepth`, `Quality` is used.
-// StripMetadata does nothing to Gif images.
+// GifExportParams are options when exporting a GIF to file or buffer.
+//
+// For vips 8.12+, native gifsave is used. The relevant parameters are Dither,
+// Effort, and Bitdepth. Quality is ignored because native gifsave does not
+// support a quality parameter.
+//
+// For vips below 8.12, magicksave is used as a fallback. The relevant
+// parameters are Quality and Bitdepth.
+//
+// StripMetadata has no effect on GIF images.
 type GifExportParams struct {
 	StripMetadata bool
-	Quality       int
-	Dither        float64
-	Effort        int
-	Bitdepth      int
+	// Quality is only used with vips < 8.12 (magicksave fallback).
+	// Ignored by native gifsave in vips 8.12+.
+	Quality  int
+	Dither   float64
+	Effort   int
+	Bitdepth int
 }
 
 // NewGifExportParams creates default values for an export of a GIF image.


### PR DESCRIPTION
## Summary
- Fixes #359
- The `Quality` field in `GifExportParams` is silently ignored by native `gifsave` in vips 8.12+, which only supports `Dither`, `Effort`, and `Bitdepth`
- Updated struct and field comments to clearly document this limitation

## Test plan
- [ ] Documentation-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify GIF export docs in `vips.GifExportParams` to note `Quality` applies only to vips < 8.12 and is ignored by native `gifsave`
> Update struct-level and inline documentation in [image.go](https://github.com/davidbyttow/govips/pull/501/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b) to detail version-specific behavior for GIF export fields, including `Quality` usage below vips 8.12 and `Dither`/`Effort`/`Bitdepth` with native `gifsave` in 8.12+.
>
> #### 📍Where to Start
> Start with the `vips.GifExportParams` documentation in [image.go](https://github.com/davidbyttow/govips/pull/501/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a8bfd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->