### PR TITLE
Add NewTransparentCanvas helper

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -621,6 +621,27 @@ func Black(width, height int) (*ImageRef, error) {
 	return imageRef, err
 }
 
+// NewTransparentCanvas creates a fully transparent RGBA image of the given dimensions.
+// The image is in sRGB color space with 4 bands (RGBA), all channels set to 0.
+func NewTransparentCanvas(width, height int) (*ImageRef, error) {
+	ref, err := Black(width, height)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ref.ToColorSpace(InterpretationSRGB); err != nil {
+		ref.Close()
+		return nil, err
+	}
+
+	if err := ref.BandJoinConst([]float64{0}); err != nil {
+		ref.Close()
+		return nil, err
+	}
+
+	return ref, nil
+}
+
 // Text draws the string text to an image.
 func Text(params *TextParams) (*ImageRef, error) {
 	img, err := vipsText(params)


### PR DESCRIPTION
## Summary
- Fixes #306
- Adds `NewTransparentCanvas(width, height int) (*ImageRef, error)` for creating fully transparent RGBA images in a single call
- Uses `Black()` + `ToColorSpace(sRGB)` + `BandJoinConst([]float64{0})` internally

## Test plan
- [x] `TestNewTransparentCanvas`: verifies dimensions, bands, alpha, pixel values
- [x] `TestNewTransparentCanvas_Composite`: verifies compositing works on the canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `vips.NewTransparentCanvas` to create an sRGB RGBA canvas with all channels set to 0
> Introduce `vips.NewTransparentCanvas` in [vips/image.go](https://github.com/davidbyttow/govips/pull/502/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b) that builds a 4-band sRGB image via `Black`, `ToColorSpace`, and `BandJoinConst`, with tests covering creation and compositing in [vips/image_golden_test.go](https://github.com/davidbyttow/govips/pull/502/files#diff-54b8f75437b3a69844680a211e257154f94a1d779edfc330ae8963b60e3993b0).
>
> #### 📍Where to Start
> Start with the `vips.NewTransparentCanvas` function in [vips/image.go](https://github.com/davidbyttow/govips/pull/502/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d35a171.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->