### PR TITLE
Preserve loop/delay metadata in RemoveMetadata, add Loop API

### DIFF
--- a/vips/header.c
+++ b/vips/header.c
@@ -91,6 +91,18 @@ void set_image_delay(VipsImage *in, const int *array, int n) {
   return vips_image_set_array_int(in, "delay", array, n);
 }
 
+int get_image_loop(VipsImage *in) {
+  int loop = 0;
+  if (vips_image_get_typeof(in, "loop") != 0) {
+    vips_image_get_int(in, "loop", &loop);
+  }
+  return loop;
+}
+
+void set_image_loop(VipsImage *in, int loop) {
+  vips_image_set_int(in, "loop", loop);
+}
+
 void image_set_double(VipsImage *in, const char *name, double i) {
   vips_image_set_double(in, name, i);
 }

--- a/vips/header.go
+++ b/vips/header.go
@@ -84,6 +84,8 @@ var technicalMetadata = []string{
 	C.VIPS_META_ORIENTATION,
 	C.VIPS_META_N_PAGES,
 	C.VIPS_META_PAGE_HEIGHT,
+	"delay",
+	"loop",
 }
 
 func contains(a []string, x string) bool {
@@ -147,6 +149,14 @@ func vipsImageSetDelay(in *C.VipsImage, data []C.int) error {
 		C.set_image_delay(in, &data[0], C.int(n))
 	}
 	return nil
+}
+
+func vipsImageGetLoop(in *C.VipsImage) int {
+	return int(C.get_image_loop(in))
+}
+
+func vipsImageSetLoop(in *C.VipsImage, loop int) {
+	C.set_image_loop(in, C.int(loop))
 }
 
 func vipsImageGetBackground(in *C.VipsImage) ([]float64, error) {

--- a/vips/header.h
+++ b/vips/header.h
@@ -28,6 +28,8 @@ void set_page_height(VipsImage *in, int height);
 int get_meta_loader(const VipsImage *in, const char **out);
 int get_image_delay(VipsImage *in, int **out);
 void set_image_delay(VipsImage *in, const int *array, int n);
+int get_image_loop(VipsImage *in);
+void set_image_loop(VipsImage *in, int loop);
 int get_background(VipsImage *in, double **out, int *n);
 
 void image_set_blob(VipsImage *in, const char *name, const void *data,

--- a/vips/image.go
+++ b/vips/image.go
@@ -874,6 +874,21 @@ func (r *ImageRef) SetPageDelay(delay []int) error {
 	return vipsImageSetDelay(r.image, data)
 }
 
+// Loop returns the loop count for animated images.
+// A value of 0 means infinite looping.
+func (r *ImageRef) Loop() int {
+	defer runtime.KeepAlive(r)
+	return vipsImageGetLoop(r.image)
+}
+
+// SetLoop sets the loop count for animated images.
+// A value of 0 means infinite looping.
+func (r *ImageRef) SetLoop(loop int) error {
+	defer runtime.KeepAlive(r)
+	vipsImageSetLoop(r.image, loop)
+	return nil
+}
+
 // Background get the background of image.
 func (r *ImageRef) Background() ([]float64, error) {
 	defer runtime.KeepAlive(r)

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -406,6 +406,56 @@ func TestImageRef_RemoveMetadata__RetainsPageHeight(t *testing.T) {
 	assert.Equal(t, 128, image.PageHeight())
 }
 
+func TestImageRef_Loop(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	image, err := NewImageFromFile(resources + "gif-animated.gif")
+	require.NoError(t, err)
+
+	err = image.SetLoop(3)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, image.Loop())
+
+	err = image.SetLoop(0)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, image.Loop())
+}
+
+func TestImageRef_RemoveMetadata__RetainsLoop(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	image, err := NewImageFromFile(resources + "gif-animated.gif")
+	require.NoError(t, err)
+
+	err = image.SetLoop(5)
+	require.NoError(t, err)
+
+	err = image.RemoveMetadata()
+	require.NoError(t, err)
+
+	assert.Equal(t, 5, image.Loop())
+}
+
+func TestImageRef_RemoveMetadata__RetainsDelay(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	image, err := NewImageFromFile(resources + "gif-animated.gif")
+	require.NoError(t, err)
+
+	delay, err := image.PageDelay()
+	require.NoError(t, err)
+	require.NotNil(t, delay)
+
+	err = image.RemoveMetadata()
+	require.NoError(t, err)
+
+	delayAfter, err := image.PageDelay()
+	require.NoError(t, err)
+	assert.Equal(t, delay, delayAfter)
+}
+
 // Known issue: libvips does not write EXIF into WebP:
 // https://github.com/libvips/libvips/pull/1745
 func TestImageRef_RemoveMetadata__RetainsOrientation__WebP(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes #381
- `RemoveMetadata()` was stripping `"delay"` and `"loop"` animation metadata, causing GIF-to-WebP conversions to lose frame timing and loop count
- Added `"delay"` and `"loop"` to the `technicalMetadata` preserve list
- Added `Loop()` / `SetLoop()` public methods on `ImageRef` for reading and writing the loop count

## Test plan
- [x] `TestImageRef_Loop`: get/set loop count on animated GIF
- [x] `TestImageRef_RemoveMetadata__RetainsLoop`: verify loop count survives RemoveMetadata
- [x] `TestImageRef_RemoveMetadata__RetainsDelay`: verify delay array survives RemoveMetadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve delay/loop metadata in `ImageRef.RemoveMetadata` and add `ImageRef.Loop`/`ImageRef.SetLoop` APIs in [image.go](https://github.com/davidbyttow/govips/pull/503/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b)
> Add C helpers `get_image_loop`/`set_image_loop`, expose Go wrappers `vipsImageGetLoop`/`vipsImageSetLoop`, expand `technicalMetadata` to include `delay` and `loop`, and add `ImageRef.Loop`/`ImageRef.SetLoop` methods. Tests cover loop persistence and delay retention after `RemoveMetadata`.
>
> #### 📍Where to Start
> Start with `technicalMetadata` and the loop accessors in [header.go](https://github.com/davidbyttow/govips/pull/503/files#diff-b41e5769bd24805ad3c71430bded30dca18c71728eea3a86c61643dd45ed5553), then review `ImageRef.Loop`/`ImageRef.SetLoop` in [image.go](https://github.com/davidbyttow/govips/pull/503/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83af6c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->