### PR TITLE
Reduce hand-written C bridge code

### DIFF
--- a/cmd/vipsgen/config.go
+++ b/cmd/vipsgen/config.go
@@ -133,11 +133,8 @@ var excludeOps = map[string]bool{
 	"addalpha": true, // only a VipsOperation class since 8.16
 
 	// Hand-written multi-page handling.
-	"embed":        true,
-	"extract_area": true,
-	"flip":         true,
-	"crop":         true,
-	"smartcrop":    true,
+	"embed": true,
+	"crop":  true,
 
 	// Draw operations (in-place mutation, array double ink).
 	"draw_rect":   true,

--- a/vips/conversion.c
+++ b/vips/conversion.c
@@ -110,46 +110,6 @@ int embed_multi_page_image_background(VipsImage *in, VipsImage **out, int left, 
   return 0;
 }
 
-int flip_image(VipsImage *in, VipsImage **out, int direction) {
-  return vips_flip(in, out, direction, NULL);
-}
-
-int extract_image_area(VipsImage *in, VipsImage **out, int left, int top,
-                       int width, int height) {
-  return vips_extract_area(in, out, left, top, width, height, NULL);
-}
-
-int extract_area_multi_page(VipsImage *in, VipsImage **out, int left, int top, int width, int height) {
-  VipsObject *base = VIPS_OBJECT(vips_image_new());
-  int page_height = vips_image_get_page_height(in);
-  int n_pages = in->Ysize / page_height;
-
-  VipsImage **page = (VipsImage **) vips_object_local_array(base, n_pages);
-  VipsImage **copy = (VipsImage **) vips_object_local_array(base, 1);
-
-  // split image into cropped frames
-  for (int i = 0; i < n_pages; i++) {
-    if(vips_extract_area(in, &page[i], left, page_height * i + top, width, height, NULL)) {
-      g_object_unref(base);
-      return -1;
-    }
-  }
-  // reassemble frames and set page height
-  // copy before modifying metadata
-  if(
-    vips_arrayjoin(page, &copy[0], n_pages, "across", 1, NULL) ||
-    vips_copy(copy[0], out, NULL)
-  ) {
-    g_object_unref(base);
-    return -1;
-  }
-  vips_image_set_int(*out, VIPS_META_PAGE_HEIGHT, height);
-  g_object_unref(base);
-  return 0;
-}
-
-
-
 
 int similarity(VipsImage *in, VipsImage **out, double scale, double angle,
                double r, double g, double b, double a, double idx, double idy,
@@ -179,12 +139,6 @@ int similarity(VipsImage *in, VipsImage **out, double scale, double angle,
 
   vips_area_unref(VIPS_AREA(vipsBackground));
   return code;
-}
-
-int smartcrop(VipsImage *in, VipsImage **out, int width, int height,
-              int interesting) {
-  return vips_smartcrop(in, out, width, height, "interesting", interesting,
-                        NULL);
 }
 
 int crop(VipsImage *in, VipsImage **out, int left, int top,

--- a/vips/conversion.h
+++ b/vips/conversion.h
@@ -12,15 +12,6 @@ int embed_multi_page_image(VipsImage *in, VipsImage **out, int left, int top, in
 int embed_multi_page_image_background(VipsImage *in, VipsImage **out, int left, int top,
                 int width, int height, double r, double g, double b, double a);
 
-int flip_image(VipsImage *in, VipsImage **out, int direction);
-
-int extract_image_area(VipsImage *in, VipsImage **out, int left, int top,
-                       int width, int height);
-int extract_area_multi_page(VipsImage *in, VipsImage **out, int left, int top,
-                       int width, int height);
-
-int smartcrop(VipsImage *in, VipsImage **out, int width, int height,
-              int interesting);
 int crop(VipsImage *in, VipsImage **out, int left, int top,
               int width, int height);
 

--- a/vips/gen_conversion.c
+++ b/vips/gen_conversion.c
@@ -420,6 +420,30 @@ error:
     return -1;
 }
 
+int gen_vips_extract_area(VipsImage * input, int left, int top, int width, int height, VipsImage ** out_out) {
+    VipsOperation *op = vips_operation_new("extract_area");
+    if (!op) return -1;
+
+    if (vips_object_set(VIPS_OBJECT(op), "input", input, NULL)) goto error;
+    if (vips_object_set(VIPS_OBJECT(op), "left", left, NULL)) goto error;
+    if (vips_object_set(VIPS_OBJECT(op), "top", top, NULL)) goto error;
+    if (vips_object_set(VIPS_OBJECT(op), "width", width, NULL)) goto error;
+    if (vips_object_set(VIPS_OBJECT(op), "height", height, NULL)) goto error;
+
+    if (vips_cache_operation_buildp(&op)) goto error;
+
+    g_object_get(VIPS_OBJECT(op), "out", out_out, NULL);
+
+    vips_object_unref_outputs(VIPS_OBJECT(op));
+    g_object_unref(op);
+    return 0;
+
+error:
+    vips_object_unref_outputs(VIPS_OBJECT(op));
+    g_object_unref(op);
+    return -1;
+}
+
 int gen_vips_extract_band(VipsImage * input, int band, VipsImage ** out_out, GenExtractBandOpts *opts) {
     VipsOperation *op = vips_operation_new("extract_band");
     if (!op) return -1;
@@ -485,6 +509,27 @@ int gen_vips_flatten(VipsImage * input, VipsImage ** out_out, GenFlattenOpts *op
             vips_object_set(VIPS_OBJECT(op), "max-alpha", opts->maxAlpha, NULL);
         }
     }
+
+    if (vips_cache_operation_buildp(&op)) goto error;
+
+    g_object_get(VIPS_OBJECT(op), "out", out_out, NULL);
+
+    vips_object_unref_outputs(VIPS_OBJECT(op));
+    g_object_unref(op);
+    return 0;
+
+error:
+    vips_object_unref_outputs(VIPS_OBJECT(op));
+    g_object_unref(op);
+    return -1;
+}
+
+int gen_vips_flip(VipsImage * input, VipsDirection direction, VipsImage ** out_out) {
+    VipsOperation *op = vips_operation_new("flip");
+    if (!op) return -1;
+
+    if (vips_object_set(VIPS_OBJECT(op), "in", input, NULL)) goto error;
+    if (vips_object_set(VIPS_OBJECT(op), "direction", (int)direction, NULL)) goto error;
 
     if (vips_cache_operation_buildp(&op)) goto error;
 
@@ -911,6 +956,39 @@ int gen_vips_sequential(VipsImage * input, VipsImage ** out_out, GenSequentialOp
     if (vips_cache_operation_buildp(&op)) goto error;
 
     g_object_get(VIPS_OBJECT(op), "out", out_out, NULL);
+
+    vips_object_unref_outputs(VIPS_OBJECT(op));
+    g_object_unref(op);
+    return 0;
+
+error:
+    vips_object_unref_outputs(VIPS_OBJECT(op));
+    g_object_unref(op);
+    return -1;
+}
+
+int gen_vips_smartcrop(VipsImage * input, int width, int height, int * out_attentionX, VipsImage ** out_out, int * out_attentionY, GenSmartcropOpts *opts) {
+    VipsOperation *op = vips_operation_new("smartcrop");
+    if (!op) return -1;
+
+    if (vips_object_set(VIPS_OBJECT(op), "input", input, NULL)) goto error;
+    if (vips_object_set(VIPS_OBJECT(op), "width", width, NULL)) goto error;
+    if (vips_object_set(VIPS_OBJECT(op), "height", height, NULL)) goto error;
+
+    if (opts) {
+        if (opts->has_interesting) {
+            vips_object_set(VIPS_OBJECT(op), "interesting", (int)opts->interesting, NULL);
+        }
+        if (opts->has_premultiplied) {
+            vips_object_set(VIPS_OBJECT(op), "premultiplied", (gboolean)opts->premultiplied, NULL);
+        }
+    }
+
+    if (vips_cache_operation_buildp(&op)) goto error;
+
+    g_object_get(VIPS_OBJECT(op), "attention-x", out_attentionX, NULL);
+    g_object_get(VIPS_OBJECT(op), "out", out_out, NULL);
+    g_object_get(VIPS_OBJECT(op), "attention-y", out_attentionY, NULL);
 
     vips_object_unref_outputs(VIPS_OBJECT(op));
     g_object_unref(op);

--- a/vips/gen_conversion.go
+++ b/vips/gen_conversion.go
@@ -432,6 +432,21 @@ func vipsGenCopy(input *C.VipsImage, opts *CopyOptions) (*C.VipsImage, error) {
 	return out_out, nil
 }
 
+// vipsGenExtractArea calls the vips extract_area operation.
+// extract an area from an image
+func vipsGenExtractArea(input *C.VipsImage, left int, top int, width int, height int) (*C.VipsImage, error) {
+	incOpCounter("extract_area")
+
+	var out_out *C.VipsImage
+
+	ret := C.gen_vips_extract_area(input, C.int(left), C.int(top), C.int(width), C.int(height), &out_out)
+	if ret != 0 {
+		return nil, handleImageError(out_out)
+	}
+
+	return out_out, nil
+}
+
 // ExtractBandOptions are optional parameters for extract_band.
 type ExtractBandOptions struct {
 	N *int
@@ -505,6 +520,21 @@ func vipsGenFlatten(input *C.VipsImage, opts *FlattenOptions) (*C.VipsImage, err
 	}
 
 	ret := C.gen_vips_flatten(input, &out_out, &cOpts)
+	if ret != 0 {
+		return nil, handleImageError(out_out)
+	}
+
+	return out_out, nil
+}
+
+// vipsGenFlip calls the vips flip operation.
+// flip an image
+func vipsGenFlip(input *C.VipsImage, direction Direction) (*C.VipsImage, error) {
+	incOpCounter("flip")
+
+	var out_out *C.VipsImage
+
+	ret := C.gen_vips_flip(input, C.VipsDirection(direction), &out_out)
 	if ret != 0 {
 		return nil, handleImageError(out_out)
 	}
@@ -935,6 +965,41 @@ func vipsGenSequential(input *C.VipsImage, opts *SequentialOptions) (*C.VipsImag
 	}
 
 	return out_out, nil
+}
+
+// SmartcropOptions are optional parameters for smartcrop.
+type SmartcropOptions struct {
+	Interesting *Interesting
+	Premultiplied *bool
+}
+
+// vipsGenSmartcrop calls the vips smartcrop operation.
+// extract an area from an image
+func vipsGenSmartcrop(input *C.VipsImage, width int, height int, opts *SmartcropOptions) (int, *C.VipsImage, int, error) {
+	incOpCounter("smartcrop")
+
+	var out_attentionX C.int
+	var out_out *C.VipsImage
+	var out_attentionY C.int
+
+	var cOpts C.GenSmartcropOpts
+	if opts != nil {
+		if opts.Interesting != nil {
+			cOpts.has_interesting = 1
+			cOpts.interesting = C.VipsInteresting(*opts.Interesting)
+		}
+		if opts.Premultiplied != nil {
+			cOpts.has_premultiplied = 1
+			cOpts.premultiplied = C.int(boolToInt(*opts.Premultiplied))
+		}
+	}
+
+	ret := C.gen_vips_smartcrop(input, C.int(width), C.int(height), &out_attentionX, &out_out, &out_attentionY, &cOpts)
+	if ret != 0 {
+		return 0, nil, 0, handleImageError(out_out)
+	}
+
+	return int(out_attentionX), out_out, int(out_attentionY), nil
 }
 
 // SubsampleOptions are optional parameters for subsample.

--- a/vips/gen_conversion.h
+++ b/vips/gen_conversion.h
@@ -113,6 +113,8 @@ typedef struct {
 
 int gen_vips_copy(VipsImage * input, VipsImage ** out_out, GenCopyOpts *opts);
 
+int gen_vips_extract_area(VipsImage * input, int left, int top, int width, int height, VipsImage ** out_out);
+
 typedef struct {
     int has_n;
     int n;
@@ -130,6 +132,8 @@ typedef struct {
 } GenFlattenOpts;
 
 int gen_vips_flatten(VipsImage * input, VipsImage ** out_out, GenFlattenOpts *opts);
+
+int gen_vips_flip(VipsImage * input, VipsDirection direction, VipsImage ** out_out);
 
 typedef struct {
     int has_exponent;
@@ -233,6 +237,15 @@ typedef struct {
 } GenSequentialOpts;
 
 int gen_vips_sequential(VipsImage * input, VipsImage ** out_out, GenSequentialOpts *opts);
+
+typedef struct {
+    int has_interesting;
+    VipsInteresting interesting;
+    int has_premultiplied;
+    int premultiplied;
+} GenSmartcropOpts;
+
+int gen_vips_smartcrop(VipsImage * input, int width, int height, int * out_attentionX, VipsImage ** out_out, int * out_attentionY, GenSmartcropOpts *opts);
 
 typedef struct {
     int has_point;

--- a/vips/resample.c
+++ b/vips/resample.c
@@ -1,20 +1,5 @@
 #include "resample.h"
 
-int shrink_image(VipsImage *in, VipsImage **out, double xshrink,
-                 double yshrink) {
-  return vips_shrink(in, out, xshrink, yshrink, NULL);
-}
-
-int reduce_image(VipsImage *in, VipsImage **out, double xshrink,
-                 double yshrink) {
-  return vips_reduce(in, out, xshrink, yshrink, NULL);
-}
-
-int affine_image(VipsImage *in, VipsImage **out, double a, double b, double c,
-                 double d, VipsInterpolate *interpolator) {
-  return vips_affine(in, out, a, b, c, d, "interpolate", interpolator, NULL);
-}
-
 int resize_image(VipsImage *in, VipsImage **out, double scale, gdouble vscale,
                  int kernel) {
   if (vscale > 0) {

--- a/vips/resample.h
+++ b/vips/resample.h
@@ -3,12 +3,6 @@
 #include <stdlib.h>
 #include <vips/vips.h>
 
-int shrink_image(VipsImage *in, VipsImage **out, double xshrink,
-                 double yshrink);
-int reduce_image(VipsImage *in, VipsImage **out, double xshrink,
-                 double yshrink);
-int affine_image(VipsImage *in, VipsImage **out, double a, double b, double c,
-                 double d, VipsInterpolate *interpolator);
 int resize_image(VipsImage *in, VipsImage **out, double scale, gdouble vscale,
                  int kernel);
 int thumbnail(const char *filename, VipsImage **out, int width, int height,


### PR DESCRIPTION
## Summary
- Remove dead C code from resample.c/h (`shrink_image`, `reduce_image`, `affine_image`, never called from Go)
- Un-exclude `flip`, `extract_area`, `smartcrop` from the code generator and switch Go callers to use generated wrappers
- Rewrite `extract_area_multi_page` in pure Go using generated `vipsGenExtractArea`, `vipsGenArrayjoin`, `vipsGenCopy`
- Net: -108 lines of hand-written C, replaced by generated code

## Test plan
- [x] `go build ./vips/` compiles cleanly
- [x] `go vet ./vips/` passes
- [x] Targeted tests pass: `TestImage_(Flip|Crop|SmartCrop|ExtractArea|Embed|Resize|Shrink)`
- [x] GIF animated multi-page tests pass: `TestImage_GIF_Animated_(Crop|Embed|Resize|PageDelay)`
- [x] Full test suite passes (only pre-existing `TestImage_GIF_Animated_to_WebP` SIGSEGV on master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace hand-written C bridges with generated bindings for `vipsGenFlip`, `vipsGenExtractArea`, and `vipsGenSmartcrop` and reimplement multi-page extract in Go in [conversion.go](https://github.com/davidbyttow/govips/pull/507/files#diff-e6ad0c3a15f55e22b825ff89228b1d207b4ffff4e96d42306d7b2a52c341b178)
> Removes custom C wrappers, enables generated ops for `flip`, `extract_area`, and `smartcrop`, and moves multi-page `extract_area` logic into Go using generated helpers and explicit cleanup.
>
> #### 📍Where to Start
> Start with the multi-page extract logic in `vipsExtractAreaMultiPage` in [conversion.go](https://github.com/davidbyttow/govips/pull/507/files#diff-e6ad0c3a15f55e22b825ff89228b1d207b4ffff4e96d42306d7b2a52c341b178).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7b7586.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->