### PR TITLE
Add animated AVIF (avis) detection support

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -233,6 +233,7 @@ var heis = []byte("heis")
 var mif1 = []byte("mif1")
 var msf1 = []byte("msf1")
 var avif = []byte("avif")
+var avis = []byte("avis")
 
 func isHEIF(buf []byte) bool {
 	return bytes.Equal(buf[4:8], ftyp) && (bytes.Equal(buf[8:12], heic) ||
@@ -245,7 +246,8 @@ func isHEIF(buf []byte) bool {
 }
 
 func isAVIF(buf []byte) bool {
-	return bytes.Equal(buf[4:8], ftyp) && bytes.Equal(buf[8:12], avif)
+	return bytes.Equal(buf[4:8], ftyp) &&
+		(bytes.Equal(buf[8:12], avif) || bytes.Equal(buf[8:12], avis))
 }
 
 var svg = []byte("<svg")

--- a/vips/foreign_test.go
+++ b/vips/foreign_test.go
@@ -152,6 +152,18 @@ func Test_DetermineImageType__AVIF(t *testing.T) {
 	assert.Equal(t, ImageTypeAVIF, imageType)
 }
 
+func Test_DetermineImageType__AVIF_Animated(t *testing.T) {
+	require.NoError(t, Startup(&Config{}))
+
+	// Construct a minimal ftyp box with "avis" brand (Animated AVIF)
+	buf := make([]byte, 16)
+	copy(buf[4:8], "ftyp")
+	copy(buf[8:12], "avis")
+
+	imageType := DetermineImageType(buf)
+	assert.Equal(t, ImageTypeAVIF, imageType)
+}
+
 func Test_DetermineImageType__JP2K(t *testing.T) {
 	require.NoError(t, Startup(&Config{}))
 


### PR DESCRIPTION
## Summary
- Fixes #509
- Adds `avis` brand matching to `isAVIF`, so `DetermineImageType` correctly returns `ImageTypeAVIF` for animated AVIF files
- Adds a test using a synthetic ftyp box with the `avis` brand

## Test plan
- [x] `Test_DetermineImageType__AVIF_Animated` passes with synthetic `avis` ftyp buffer
- [x] Existing `Test_DetermineImageType__AVIF` still passes for static AVIF

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect animated AVIF by updating `vips.isAVIF` to accept brand `avis` with `ftyp` at bytes 4–8 in [foreign.go](https://github.com/davidbyttow/govips/pull/513/files#diff-ec94a2793e4149e5e3c5e926e52086a17d586f71fe03e67405c96512de0d6181)
> Update brand matching to treat `avis` as AVIF alongside `avif` and add a test for animated AVIF detection in [foreign_test.go](https://github.com/davidbyttow/govips/pull/513/files#diff-ab13cb8efcc84796a5ccc8ad98f90acc662682b0d9c514b125120d461cfbdb10).
>
> #### 📍Where to Start
> Start with the `isAVIF` function in [foreign.go](https://github.com/davidbyttow/govips/pull/513/files#diff-ec94a2793e4149e5e3c5e926e52086a17d586f71fe03e67405c96512de0d6181).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95b0cf3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->