### PR TITLE
Update CI: align Go version and bump action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version: ^1.23
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install linux deps
         run: |


### PR DESCRIPTION
## Summary
- Bumps `go-version` from `^1.21` to `^1.23` to match `go.mod` requirement
- Updates `actions/setup-go` from v2 to v5
- Updates `actions/checkout` from v2 to v4

## Test plan
- CI should pass with the updated versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update CI to use Go 1.23 and bump action versions
> Updates [build.yml](.github/workflows/build.yml) to use Go 1.23 (up from 1.21), `actions/setup-go` v5 (up from v2), and `actions/checkout` v4 (up from v2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4b6573.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->