### PR TITLE
Update README example to use current export API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ func main() {
 	err = image1.AutoRotate()
 	checkError(err)
 
-	ep := vips.NewDefaultJPEGExportParams()
-	image1bytes, _, err := image1.Export(ep)
+	ep := vips.NewJpegExportParams()
+	image1bytes, _, err := image1.ExportJpeg(ep)
 	err = os.WriteFile("output.jpg", image1bytes, 0644)
 	checkError(err)
 


### PR DESCRIPTION
## Summary
- Replaces deprecated `NewDefaultJPEGExportParams()` + `Export()` with `NewJpegExportParams()` + `ExportJpeg()`
- Prevents new users from adopting deprecated patterns

## Test plan
- No code changes, just documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README Go example to use current export API
> Replaces deprecated `vips.NewDefaultJPEGExportParams()` and `image1.Export(ep)` calls in the [README.md](https://github.com/davidbyttow/govips/pull/520/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with `vips.NewJpegExportParams()` and `image1.ExportJpeg(ep)`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35f836a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->