### PR TITLE
Replace deprecated GetPageHeight with PageHeight

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -1996,7 +1996,7 @@ func (r *ImageRef) ResizeWithVScale(hScale, vScale float64, kernel Kernel) error
 	}
 
 	pages := r.Pages()
-	pageHeight := r.GetPageHeight()
+	pageHeight := r.PageHeight()
 
 	out, err := vipsResizeWithVScale(r.image, hScale, vScale, kernel)
 	if err != nil {
@@ -2193,7 +2193,7 @@ func (r *ImageRef) Rotate(angle Angle) error {
 			}
 		}
 
-		if err := r.Grid(r.GetPageHeight(), r.Pages(), 1); err != nil {
+		if err := r.Grid(r.PageHeight(), r.Pages(), 1); err != nil {
 			return err
 		}
 

--- a/vips/image_gif_test.go
+++ b/vips/image_gif_test.go
@@ -70,7 +70,7 @@ func TestImage_GIF_Animated_ResizeWithVScale(t *testing.T) {
 		},
 		func(img *ImageRef) {
 			assert.Equal(t, 3, img.Pages())
-			assert.Equal(t, 100, img.GetPageHeight())
+			assert.Equal(t, 100, img.PageHeight())
 		},
 		nil)
 }
@@ -134,7 +134,7 @@ func TestImage_GIF_Animated_Crop(t *testing.T) {
 			return img.Crop(10, 20, 20, 20)
 		},
 		func(img *ImageRef) {
-			assert.Equal(t, img.GetPageHeight(), 20)
+			assert.Equal(t, img.PageHeight(), 20)
 		},
 		nil)
 }

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -1851,14 +1851,14 @@ func TestRotate_Animated(t *testing.T) {
 
 	require.Greater(t, img.Pages(), 1)
 	origW := img.Width()
-	origPageH := img.GetPageHeight()
+	origPageH := img.PageHeight()
 
 	err = img.Rotate(Angle90)
 	require.NoError(t, err)
 
 	// Width/height should swap per page
 	assert.Equal(t, origPageH, img.Width())
-	assert.Equal(t, origW, img.GetPageHeight())
+	assert.Equal(t, origW, img.PageHeight())
 }
 
 func TestPixelate(t *testing.T) {


### PR DESCRIPTION
## Summary
- Updates `image.go` (ResizeWithVScale, Rotate) to use `PageHeight()` instead of deprecated `GetPageHeight()`
- Updates tests in `image_test.go` and `image_gif_test.go` to match

## Test plan
- CI tests should pass, behavior is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace deprecated `GetPageHeight` with `PageHeight` in image operations
> Updates calls to the deprecated `GetPageHeight` method to use `PageHeight` in [image.go](https://github.com/davidbyttow/govips/pull/521/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b) and related tests. No behavioral changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4776d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->