### PR TITLE
Replace panic() with t.Fatal() in test helpers

### DIFF
--- a/vips/image_golden_helpers_test.go
+++ b/vips/image_golden_helpers_test.go
@@ -197,7 +197,7 @@ func getEnvironment() string {
 func assertGoldenMatch(t *testing.T, file string, buf []byte, format ImageType) {
 	i := strings.LastIndex(file, ".")
 	if i < 0 {
-		panic("bad filename")
+		t.Fatal("bad filename")
 	}
 
 	name := strings.Replace(t.Name(), "/", "_", -1)
@@ -213,7 +213,7 @@ func assertGoldenMatch(t *testing.T, file string, buf []byte, format ImageType) 
 			failed := prefix + "-" + getEnvironment() + ".failed" + ext
 			err := os.WriteFile(failed, buf, 0666)
 			if err != nil {
-				panic(err)
+				t.Fatalf("failed to write failed golden file: %v", err)
 			}
 		}
 		return


### PR DESCRIPTION
## Summary
- Replaces `panic("bad filename")` with `t.Fatal("bad filename")` in `assertGoldenMatch`
- Replaces `panic(err)` with `t.Fatalf(...)` for golden file write failure
- Keeps `panic(err)` in `mem_tests/TestMain` where no `t` is available (appropriate there)

## Test plan
- CI tests should pass, only changes error reporting path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `panic()` with `t.Fatal()` in `assertGoldenMatch` test helper
> Fixes improper use of `panic` in [vips/image_golden_helpers_test.go](https://github.com/davidbyttow/govips/pull/522/files#diff-d0bb7ed5c4ae68020c6912dac9089eaa734db5df1c42c2fdfb4f08cdb53fad03) so test failures are reported through the standard `testing.T` mechanism instead of crashing the test process.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6540a28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->