### PR TITLE
Return error from startupIfNeeded instead of panicking

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -146,7 +146,10 @@ func (i ImageType) FileExt() string {
 
 // IsTypeSupported checks whether given image type is supported by govips
 func IsTypeSupported(imageType ImageType) bool {
-	startupIfNeeded()
+	if err := startupIfNeeded(); err != nil {
+		govipsLog("govips", LogLevelError, fmt.Sprintf("failed to start vips: %v", err))
+		return false
+	}
 
 	// BMP is supported via the magick loader
 	if imageType == ImageTypeBMP {

--- a/vips/govips.go
+++ b/vips/govips.go
@@ -233,13 +233,14 @@ func ReadVipsMemStats(stats *MemoryStats) {
 	stats.Files = int64(C.vips_tracked_get_files())
 }
 
-func startupIfNeeded() {
+func startupIfNeeded() error {
 	if !running {
 		govipsLog("govips", LogLevelInfo, "libvips was forcibly started automatically, consider calling Startup/Shutdown yourself")
 		if err := Startup(nil); err != nil {
-			panic(err)
+			return err
 		}
 	}
+	return nil
 }
 
 // InitTypes initializes caches and figures out which image types are supported

--- a/vips/govips_test.go
+++ b/vips/govips_test.go
@@ -10,5 +10,5 @@ func TestInitConfig(t *testing.T) {
 	running = false
 	require.NoError(t, Startup(&Config{CollectStats: true, CacheTrace: true}))
 	running = false
-	startupIfNeeded()
+	require.NoError(t, startupIfNeeded())
 }

--- a/vips/image.go
+++ b/vips/image.go
@@ -493,7 +493,9 @@ func NewImageFromBuffer(buf []byte) (*ImageRef, error) {
 
 // LoadImageFromBuffer loads an image buffer and creates a new Image
 func LoadImageFromBuffer(buf []byte, params *ImportParams) (*ImageRef, error) {
-	startupIfNeeded()
+	if err := startupIfNeeded(); err != nil {
+		return nil, err
+	}
 
 	if params == nil {
 		params = NewImportParams()
@@ -527,7 +529,9 @@ func NewThumbnailWithSizeFromFile(file string, width, height int, crop Interesti
 
 // LoadThumbnailFromFile loads an image from file and creates a new ImageRef with thumbnail crop and size
 func LoadThumbnailFromFile(file string, width, height int, crop Interesting, size Size, params *ImportParams) (*ImageRef, error) {
-	startupIfNeeded()
+	if err := startupIfNeeded(); err != nil {
+		return nil, err
+	}
 
 	vipsImage, format, err := vipsThumbnailFromFile(file, width, height, crop, size, params)
 	if err != nil {
@@ -547,7 +551,9 @@ func NewThumbnailWithSizeFromBuffer(buf []byte, width, height int, crop Interest
 
 // LoadThumbnailFromBuffer loads an image buffer and creates a new Image with thumbnail crop and size
 func LoadThumbnailFromBuffer(buf []byte, width, height int, crop Interesting, size Size, params *ImportParams) (*ImageRef, error) {
-	startupIfNeeded()
+	if err := startupIfNeeded(); err != nil {
+		return nil, err
+	}
 
 	vipsImage, format, err := vipsThumbnailFromBuffer(buf, width, height, crop, size, params)
 	if err != nil {
@@ -2416,7 +2422,9 @@ func (r *ImageRef) ToGoImage() (image.Image, error) {
 // The image is normalized to NRGBA (non-premultiplied RGBA, 8-bit) and
 // imported into libvips in sRGB color space.
 func NewImageFromGoImage(img image.Image) (*ImageRef, error) {
-	startupIfNeeded()
+	if err := startupIfNeeded(); err != nil {
+		return nil, err
+	}
 
 	bounds := img.Bounds()
 	width := bounds.Dx()


### PR DESCRIPTION
## Summary
- Changes `startupIfNeeded()` to return `error` instead of panicking
- Updates all internal callers in `image.go` and `foreign.go` to propagate the error
- `IsTypeSupported` logs and returns `false` on startup failure (can't change public API signature)

## Test plan
- CI tests should pass
- Error paths now return meaningful errors instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return errors from `startupIfNeeded` instead of panicking on libvips startup failure
> - Changes `startupIfNeeded` in [govips.go](https://github.com/davidbyttow/govips/pull/523/files#diff-0a6557e8f943f86d8da877a624e63377e6cb93b93de71823e079a9df21944c82) to return an error instead of calling `panic` on startup failure.
> - Updates `LoadImageFromBuffer`, `LoadThumbnailFromFile`, `LoadThumbnailFromBuffer`, and `NewImageFromGoImage` in [image.go](https://github.com/davidbyttow/govips/pull/523/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b) to propagate the error to callers.
> - Updates `IsTypeSupported` in [foreign.go](https://github.com/davidbyttow/govips/pull/523/files#diff-ec94a2793e4149e5e3c5e926e52086a17d586f71fe03e67405c96512de0d6181) to log the error and return `false` instead of panicking.
> - Behavioral Change: callers that previously would have seen a panic on libvips startup failure now receive an error return value or a `false` result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9618ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->