### PR TITLE
Add composable pipeline API for image transforms

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -2238,11 +2238,8 @@ func (r *ImageRef) Recomb(matrix [][]float64) error {
 	matrixImage := C.vips_image_new_from_memory(matrixPtr, matrixSize, C.int(numBands), C.int(numBands), 1, C.VIPS_FORMAT_DOUBLE)
 	defer clearImage(matrixImage)
 
-	// Check for any Vips errors
-	errMsg := C.GoString(C.vips_error_buffer())
-	if errMsg != "" {
-		C.vips_error_clear()
-		return errors.New("Vips error: " + errMsg)
+	if matrixImage == nil {
+		return handleVipsError()
 	}
 
 	// Recombine the image using the matrix

--- a/vips/image_golden_helpers_test.go
+++ b/vips/image_golden_helpers_test.go
@@ -88,6 +88,7 @@ func goldenTest(
 
 	img, err := NewImageFromFile(path)
 	require.NoError(t, err)
+	defer img.Close()
 
 	err = exec(img)
 	require.NoError(t, err)
@@ -97,6 +98,7 @@ func goldenTest(
 
 	result, err := NewImageFromBuffer(buf)
 	require.NoError(t, err)
+	defer result.Close()
 
 	validate(result)
 
@@ -133,6 +135,7 @@ func goldenCreateTest(
 
 	img, err := createFromFile(path)
 	require.NoError(t, err)
+	defer img.Close()
 
 	err = exec(img)
 	require.NoError(t, err)
@@ -142,6 +145,7 @@ func goldenCreateTest(
 
 	result, err := NewImageFromBuffer(buf)
 	require.NoError(t, err)
+	defer result.Close()
 
 	validate(result)
 
@@ -152,6 +156,7 @@ func goldenCreateTest(
 
 	img2, err := createFromBuffer(buf2)
 	require.NoError(t, err)
+	defer img2.Close()
 
 	err = exec(img2)
 	require.NoError(t, err)
@@ -161,6 +166,7 @@ func goldenCreateTest(
 
 	result2, err := NewImageFromBuffer(buf2)
 	require.NoError(t, err)
+	defer result2.Close()
 
 	validate(result2)
 
@@ -251,6 +257,7 @@ func goldenAnimatedTest(
 
 	img, err := LoadImageFromFile(path, importParams)
 	require.NoError(t, err)
+	defer img.Close()
 
 	err = exec(img)
 	require.NoError(t, err)
@@ -260,6 +267,7 @@ func goldenAnimatedTest(
 
 	result, err := NewImageFromBuffer(buf)
 	require.NoError(t, err)
+	defer result.Close()
 
 	validate(result)
 

--- a/vips/pipeline/ops.go
+++ b/vips/pipeline/ops.go
@@ -1,0 +1,297 @@
+package pipeline
+
+import "github.com/davidbyttow/govips/v2/vips"
+
+// Geometric transforms
+
+// Resize returns an operation that resizes the image by scale using the given kernel.
+func Resize(scale float64, kernel vips.Kernel) Operation {
+	return Operation{name: "Resize", fn: func(img *vips.ImageRef) error {
+		return img.Resize(scale, kernel)
+	}}
+}
+
+// ResizeWithVScale returns an operation that resizes with separate horizontal and vertical scaling.
+func ResizeWithVScale(hScale, vScale float64, kernel vips.Kernel) Operation {
+	return Operation{name: "ResizeWithVScale", fn: func(img *vips.ImageRef) error {
+		return img.ResizeWithVScale(hScale, vScale, kernel)
+	}}
+}
+
+// Thumbnail returns an operation that resizes to exact dimensions with cropping.
+func Thumbnail(width, height int, crop vips.Interesting) Operation {
+	return Operation{name: "Thumbnail", fn: func(img *vips.ImageRef) error {
+		return img.Thumbnail(width, height, crop)
+	}}
+}
+
+// ThumbnailWithSize returns an operation that resizes with a size strategy.
+func ThumbnailWithSize(width, height int, crop vips.Interesting, size vips.Size) Operation {
+	return Operation{name: "ThumbnailWithSize", fn: func(img *vips.ImageRef) error {
+		return img.ThumbnailWithSize(width, height, crop, size)
+	}}
+}
+
+// Rotate returns an operation that rotates the image by multiples of 90 degrees.
+func Rotate(angle vips.Angle) Operation {
+	return Operation{name: "Rotate", fn: func(img *vips.ImageRef) error {
+		return img.Rotate(angle)
+	}}
+}
+
+// AutoRotate returns an operation that rotates based on EXIF orientation.
+func AutoRotate() Operation {
+	return Operation{name: "AutoRotate", fn: func(img *vips.ImageRef) error {
+		return img.AutoRotate()
+	}}
+}
+
+// Flip returns an operation that flips the image horizontally or vertically.
+func Flip(direction vips.Direction) Operation {
+	return Operation{name: "Flip", fn: func(img *vips.ImageRef) error {
+		return img.Flip(direction)
+	}}
+}
+
+// Crop returns an operation that crops the image.
+func Crop(left, top, width, height int) Operation {
+	return Operation{name: "Crop", fn: func(img *vips.ImageRef) error {
+		return img.Crop(left, top, width, height)
+	}}
+}
+
+// SmartCrop returns an operation that crops based on interesting content.
+func SmartCrop(width, height int, interesting vips.Interesting) Operation {
+	return Operation{name: "SmartCrop", fn: func(img *vips.ImageRef) error {
+		return img.SmartCrop(width, height, interesting)
+	}}
+}
+
+// ExtractArea returns an operation that extracts a region from the image.
+func ExtractArea(left, top, width, height int) Operation {
+	return Operation{name: "ExtractArea", fn: func(img *vips.ImageRef) error {
+		return img.ExtractArea(left, top, width, height)
+	}}
+}
+
+// Embed returns an operation that embeds the image in a larger canvas.
+func Embed(left, top, width, height int, extend vips.ExtendStrategy) Operation {
+	return Operation{name: "Embed", fn: func(img *vips.ImageRef) error {
+		return img.Embed(left, top, width, height, extend)
+	}}
+}
+
+// EmbedBackground returns an operation that embeds with a background color.
+func EmbedBackground(left, top, width, height int, bg *vips.Color) Operation {
+	return Operation{name: "EmbedBackground", fn: func(img *vips.ImageRef) error {
+		return img.EmbedBackground(left, top, width, height, bg)
+	}}
+}
+
+// EmbedBackgroundRGBA returns an operation that embeds with an RGBA background color.
+func EmbedBackgroundRGBA(left, top, width, height int, bg *vips.ColorRGBA) Operation {
+	return Operation{name: "EmbedBackgroundRGBA", fn: func(img *vips.ImageRef) error {
+		return img.EmbedBackgroundRGBA(left, top, width, height, bg)
+	}}
+}
+
+// Zoom returns an operation that zooms by pixel repetition.
+func Zoom(xFactor, yFactor int) Operation {
+	return Operation{name: "Zoom", fn: func(img *vips.ImageRef) error {
+		return img.Zoom(xFactor, yFactor)
+	}}
+}
+
+// Similarity returns an operation that scales, rotates, and offsets in a single step.
+func Similarity(scale, angle float64, bg *vips.ColorRGBA, idx, idy, odx, ody float64) Operation {
+	return Operation{name: "Similarity", fn: func(img *vips.ImageRef) error {
+		return img.Similarity(scale, angle, bg, idx, idy, odx, ody)
+	}}
+}
+
+// Gravity returns an operation that positions the image using gravity.
+func Gravity(gravity vips.Gravity, width, height int) Operation {
+	return Operation{name: "Gravity", fn: func(img *vips.ImageRef) error {
+		return img.Gravity(gravity, width, height)
+	}}
+}
+
+// Replicate returns an operation that repeats the image across and down.
+func Replicate(across, down int) Operation {
+	return Operation{name: "Replicate", fn: func(img *vips.ImageRef) error {
+		return img.Replicate(across, down)
+	}}
+}
+
+// Filters and effects
+
+// GaussianBlur returns an operation that applies a Gaussian blur.
+func GaussianBlur(sigma float64) Operation {
+	return Operation{name: "GaussianBlur", fn: func(img *vips.ImageRef) error {
+		return img.GaussianBlur(sigma)
+	}}
+}
+
+// Sharpen returns an operation that sharpens the image.
+func Sharpen(sigma, x1, m2 float64) Operation {
+	return Operation{name: "Sharpen", fn: func(img *vips.ImageRef) error {
+		return img.Sharpen(sigma, x1, m2)
+	}}
+}
+
+// Sobel returns an operation that applies the Sobel edge detector.
+func Sobel() Operation {
+	return Operation{name: "Sobel", fn: func(img *vips.ImageRef) error {
+		return img.Sobel()
+	}}
+}
+
+// Flatten returns an operation that removes alpha and replaces with a background color.
+func Flatten(bg *vips.Color) Operation {
+	return Operation{name: "Flatten", fn: func(img *vips.ImageRef) error {
+		return img.Flatten(bg)
+	}}
+}
+
+// Color operations
+
+// ToColorSpace returns an operation that converts to a different color space.
+func ToColorSpace(interpretation vips.Interpretation) Operation {
+	return Operation{name: "ToColorSpace", fn: func(img *vips.ImageRef) error {
+		return img.ToColorSpace(interpretation)
+	}}
+}
+
+// Modulate returns an operation that modulates brightness, saturation, and hue via LCH.
+func Modulate(brightness, saturation, hue float64) Operation {
+	return Operation{name: "Modulate", fn: func(img *vips.ImageRef) error {
+		return img.Modulate(brightness, saturation, hue)
+	}}
+}
+
+// ModulateHSV returns an operation that modulates via HSV.
+func ModulateHSV(brightness, saturation float64, hue int) Operation {
+	return Operation{name: "ModulateHSV", fn: func(img *vips.ImageRef) error {
+		return img.ModulateHSV(brightness, saturation, hue)
+	}}
+}
+
+// Invert returns an operation that inverts the image.
+func Invert() Operation {
+	return Operation{name: "Invert", fn: func(img *vips.ImageRef) error {
+		return img.Invert()
+	}}
+}
+
+// Gamma returns an operation that adjusts gamma.
+func Gamma(gamma float64) Operation {
+	return Operation{name: "Gamma", fn: func(img *vips.ImageRef) error {
+		return img.Gamma(gamma)
+	}}
+}
+
+// Recomb returns an operation that recombines bands using a matrix.
+func Recomb(matrix [][]float64) Operation {
+	return Operation{name: "Recomb", fn: func(img *vips.ImageRef) error {
+		return img.Recomb(matrix)
+	}}
+}
+
+// Arithmetic
+
+// Linear returns an operation that applies a linear transformation (output = input * a + b).
+func Linear(a, b []float64) Operation {
+	return Operation{name: "Linear", fn: func(img *vips.ImageRef) error {
+		return img.Linear(a, b)
+	}}
+}
+
+// Linear1 returns an operation that applies a single-constant linear transformation.
+func Linear1(a, b float64) Operation {
+	return Operation{name: "Linear1", fn: func(img *vips.ImageRef) error {
+		return img.Linear1(a, b)
+	}}
+}
+
+// Band operations
+
+// AddAlpha returns an operation that adds an alpha channel.
+func AddAlpha() Operation {
+	return Operation{name: "AddAlpha", fn: func(img *vips.ImageRef) error {
+		return img.AddAlpha()
+	}}
+}
+
+// ExtractBand returns an operation that extracts bands in place.
+func ExtractBand(band, num int) Operation {
+	return Operation{name: "ExtractBand", fn: func(img *vips.ImageRef) error {
+		return img.ExtractBand(band, num)
+	}}
+}
+
+// BandJoinConst returns an operation that appends constant bands.
+func BandJoinConst(constants []float64) Operation {
+	return Operation{name: "BandJoinConst", fn: func(img *vips.ImageRef) error {
+		return img.BandJoinConst(constants)
+	}}
+}
+
+// Cast returns an operation that converts to a target band format.
+func Cast(format vips.BandFormat) Operation {
+	return Operation{name: "Cast", fn: func(img *vips.ImageRef) error {
+		return img.Cast(format)
+	}}
+}
+
+// ICC profile management
+
+// RemoveICCProfile returns an operation that removes the ICC profile.
+func RemoveICCProfile() Operation {
+	return Operation{name: "RemoveICCProfile", fn: func(img *vips.ImageRef) error {
+		return img.RemoveICCProfile()
+	}}
+}
+
+// OptimizeICCProfile returns an operation that optimizes the ICC profile.
+func OptimizeICCProfile() Operation {
+	return Operation{name: "OptimizeICCProfile", fn: func(img *vips.ImageRef) error {
+		return img.OptimizeICCProfile()
+	}}
+}
+
+// TransformICCProfile returns an operation that transforms to a target ICC profile.
+func TransformICCProfile(outputProfilePath string) Operation {
+	return Operation{name: "TransformICCProfile", fn: func(img *vips.ImageRef) error {
+		return img.TransformICCProfile(outputProfilePath)
+	}}
+}
+
+// Metadata
+
+// RemoveMetadata returns an operation that removes EXIF metadata.
+func RemoveMetadata(keep ...string) Operation {
+	return Operation{name: "RemoveMetadata", fn: func(img *vips.ImageRef) error {
+		return img.RemoveMetadata(keep...)
+	}}
+}
+
+// RemoveOrientation returns an operation that removes the EXIF orientation tag.
+func RemoveOrientation() Operation {
+	return Operation{name: "RemoveOrientation", fn: func(img *vips.ImageRef) error {
+		return img.RemoveOrientation()
+	}}
+}
+
+// SetOrientation returns an operation that sets the EXIF orientation.
+func SetOrientation(orientation int) Operation {
+	return Operation{name: "SetOrientation", fn: func(img *vips.ImageRef) error {
+		return img.SetOrientation(orientation)
+	}}
+}
+
+// Label returns an operation that overlays label text on the image.
+func Label(params *vips.LabelParams) Operation {
+	return Operation{name: "Label", fn: func(img *vips.ImageRef) error {
+		return img.Label(params)
+	}}
+}

--- a/vips/pipeline/pipeline.go
+++ b/vips/pipeline/pipeline.go
@@ -1,0 +1,126 @@
+// Package pipeline provides a composable, functional API for image transforms.
+//
+// Operations are values that describe a transformation without performing it.
+// Compose them into reusable Transform chains, then apply with Apply (mutate)
+// or ApplyNew (copy first).
+//
+//	t := pipeline.Compose(
+//	    pipeline.Resize(0.5, vips.KernelLanczos3),
+//	    pipeline.AutoRotate(),
+//	    pipeline.Sharpen(1.0, 2.0, 3.0),
+//	)
+//	err := t.Apply(img)
+//
+// Export is intentionally outside the pipeline. Apply your transform, then
+// call the appropriate Export method on the resulting image.
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/davidbyttow/govips/v2/vips"
+)
+
+// Composable is implemented by types that can be used in Compose.
+// Both Operation and Transform implement this interface.
+type Composable interface {
+	operations() []Operation
+}
+
+// Operation is a single image transformation step.
+// Create operations using the provided wrapper functions (e.g. Resize, AutoRotate).
+// For custom operations, use NewOperation.
+type Operation struct {
+	name string
+	fn   func(*vips.ImageRef) error
+}
+
+func (o Operation) operations() []Operation {
+	return []Operation{o}
+}
+
+// NewOperation creates a custom Operation with the given name and function.
+// Use this to wrap custom transformations not covered by the built-in operations.
+func NewOperation(name string, fn func(*vips.ImageRef) error) Operation {
+	return Operation{name: name, fn: fn}
+}
+
+// Transform is a composable sequence of operations.
+// Transforms are created with Compose and applied with Apply or ApplyNew.
+type Transform struct {
+	ops []Operation
+}
+
+func (t Transform) operations() []Operation {
+	return t.ops
+}
+
+// Compose flattens any combination of Operations and Transforms into a single Transform.
+// Transforms nest: Compose(transformA, transformB) produces a flat sequence of all operations.
+func Compose(items ...Composable) Transform {
+	var ops []Operation
+	for _, item := range items {
+		ops = append(ops, item.operations()...)
+	}
+	return Transform{ops: ops}
+}
+
+// Apply executes all operations on img in place.
+// If any operation fails, it stops and returns an error with step context
+// (e.g. "step 2/5 Sharpen: invalid sigma"). Errors are wrapped with %w
+// so errors.Is and errors.As work on the underlying error.
+func (t Transform) Apply(img *vips.ImageRef) error {
+	total := len(t.ops)
+	for i, op := range t.ops {
+		if err := op.fn(img); err != nil {
+			return fmt.Errorf("step %d/%d %s: %w", i+1, total, op.name, err)
+		}
+	}
+	return nil
+}
+
+// ApplyNew copies the image first, then applies all operations to the copy.
+// The original image is left untouched. The caller is responsible for closing
+// the returned image when done.
+func (t Transform) ApplyNew(img *vips.ImageRef) (*vips.ImageRef, error) {
+	cp, err := img.Copy()
+	if err != nil {
+		return nil, fmt.Errorf("copy before transform: %w", err)
+	}
+	if err := t.Apply(cp); err != nil {
+		cp.Close()
+		return nil, err
+	}
+	return cp, nil
+}
+
+// Process loads an image from file, applies the given operations, and returns the result.
+// The caller is responsible for closing the returned image when done.
+// Export is intentionally not part of the pipeline — call Export on the returned image.
+func Process(path string, items ...Composable) (*vips.ImageRef, error) {
+	img, err := vips.NewImageFromFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("load %s: %w", path, err)
+	}
+	t := Compose(items...)
+	if err := t.Apply(img); err != nil {
+		img.Close()
+		return nil, err
+	}
+	return img, nil
+}
+
+// ProcessBytes loads an image from a byte buffer, applies the given operations,
+// and returns the result. The caller is responsible for closing the returned image when done.
+func ProcessBytes(buf []byte, items ...Composable) (*vips.ImageRef, error) {
+	img, err := vips.NewImageFromBuffer(buf)
+	if err != nil {
+		return nil, fmt.Errorf("load from buffer: %w", err)
+	}
+	t := Compose(items...)
+	if err := t.Apply(img); err != nil {
+		img.Close()
+		return nil, err
+	}
+	return img, nil
+}

--- a/vips/pipeline/pipeline_test.go
+++ b/vips/pipeline/pipeline_test.go
@@ -1,0 +1,295 @@
+package pipeline_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/davidbyttow/govips/v2/vips"
+	"github.com/davidbyttow/govips/v2/vips/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const resources = "../../resources/"
+
+func TestCompose_SingleOperation(t *testing.T) {
+	tr := pipeline.Compose(pipeline.AutoRotate())
+	// Verify it's composable by applying to a real image
+	require.NoError(t, vips.Startup(nil))
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+	require.NoError(t, tr.Apply(img))
+}
+
+func TestCompose_FlattenTransforms(t *testing.T) {
+	step1 := pipeline.Compose(pipeline.Resize(0.5, vips.KernelLanczos3), pipeline.AutoRotate())
+	step2 := pipeline.Compose(pipeline.Invert())
+
+	// Compose transforms together
+	combined := pipeline.Compose(step1, step2)
+
+	require.NoError(t, vips.Startup(nil))
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+
+	require.NoError(t, combined.Apply(img))
+}
+
+func TestCompose_MixedOperationsAndTransforms(t *testing.T) {
+	step1 := pipeline.Compose(pipeline.Resize(0.5, vips.KernelLanczos3))
+	combined := pipeline.Compose(step1, pipeline.AutoRotate(), pipeline.Invert())
+
+	require.NoError(t, vips.Startup(nil))
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+
+	require.NoError(t, combined.Apply(img))
+}
+
+func TestCompose_Empty(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+
+	tr := pipeline.Compose()
+	require.NoError(t, tr.Apply(img))
+}
+
+func TestApply_MutatesInPlace(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+
+	origWidth := img.Width()
+
+	tr := pipeline.Compose(pipeline.Resize(0.5, vips.KernelLanczos3))
+	require.NoError(t, tr.Apply(img))
+
+	assert.InDelta(t, origWidth/2, img.Width(), 1)
+}
+
+func TestApplyNew_PreservesOriginal(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+
+	origWidth := img.Width()
+
+	tr := pipeline.Compose(pipeline.Resize(0.5, vips.KernelLanczos3))
+	result, err := tr.ApplyNew(img)
+	require.NoError(t, err)
+	defer result.Close()
+
+	assert.Equal(t, origWidth, img.Width())
+	assert.InDelta(t, origWidth/2, result.Width(), 1)
+}
+
+func TestApply_ErrorContext(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+
+	failing := pipeline.NewOperation("BadOp", func(img *vips.ImageRef) error {
+		return errors.New("something broke")
+	})
+
+	tr := pipeline.Compose(pipeline.AutoRotate(), failing, pipeline.Invert())
+	err = tr.Apply(img)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "step 2/3 BadOp")
+	assert.Contains(t, err.Error(), "something broke")
+}
+
+func TestApply_ErrorUnwrap(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	sentinel := errors.New("sentinel error")
+	failing := pipeline.NewOperation("Fail", func(img *vips.ImageRef) error {
+		return sentinel
+	})
+
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+
+	err = pipeline.Compose(failing).Apply(img)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, sentinel))
+}
+
+func TestApply_StopsOnFirstError(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+
+	var called []string
+
+	op1 := pipeline.NewOperation("Op1", func(img *vips.ImageRef) error {
+		called = append(called, "op1")
+		return nil
+	})
+	op2 := pipeline.NewOperation("Op2", func(img *vips.ImageRef) error {
+		called = append(called, "op2")
+		return errors.New("fail")
+	})
+	op3 := pipeline.NewOperation("Op3", func(img *vips.ImageRef) error {
+		called = append(called, "op3")
+		return nil
+	})
+
+	err = pipeline.Compose(op1, op2, op3).Apply(img)
+	require.Error(t, err)
+	assert.Equal(t, []string{"op1", "op2"}, called)
+}
+
+func TestApplyNew_ErrorClosesImage(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+
+	failing := pipeline.NewOperation("Fail", func(img *vips.ImageRef) error {
+		return errors.New("boom")
+	})
+
+	result, err := pipeline.Compose(failing).ApplyNew(img)
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestProcess(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	img, err := pipeline.Process(resources+"png-24bit.png",
+		pipeline.Resize(0.5, vips.KernelLanczos3),
+		pipeline.AutoRotate(),
+	)
+	require.NoError(t, err)
+	defer img.Close()
+
+	assert.Greater(t, img.Width(), 0)
+}
+
+func TestProcess_BadPath(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	_, err := pipeline.Process("/nonexistent/file.png", pipeline.AutoRotate())
+	require.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "load "))
+}
+
+func TestProcess_WithComposedTransforms(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	resize := pipeline.Compose(pipeline.Resize(0.5, vips.KernelLanczos3))
+	cleanup := pipeline.Compose(pipeline.AutoRotate())
+
+	img, err := pipeline.Process(resources+"png-24bit.png", resize, cleanup)
+	require.NoError(t, err)
+	defer img.Close()
+
+	assert.Greater(t, img.Width(), 0)
+}
+
+func TestProcessBytes(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	src, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	buf, _, err := src.ExportPng(vips.NewPngExportParams())
+	src.Close()
+	require.NoError(t, err)
+
+	img, err := pipeline.ProcessBytes(buf, pipeline.Resize(0.5, vips.KernelLanczos3))
+	require.NoError(t, err)
+	defer img.Close()
+
+	assert.Greater(t, img.Width(), 0)
+}
+
+func TestMultiStepPipeline(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	// Define reusable presets
+	webOptimize := pipeline.Compose(
+		pipeline.Resize(0.5, vips.KernelLanczos3),
+		pipeline.AutoRotate(),
+		pipeline.Sharpen(1.0, 2.0, 10.0),
+	)
+
+	colorCorrect := pipeline.Compose(
+		pipeline.Gamma(1.2),
+	)
+
+	// Combine presets into a full pipeline
+	fullPipeline := pipeline.Compose(webOptimize, colorCorrect)
+
+	img, err := vips.NewImageFromFile(resources + "jpg-24bit.jpg")
+	require.NoError(t, err)
+	defer img.Close()
+
+	origWidth := img.Width()
+	require.NoError(t, fullPipeline.Apply(img))
+
+	// Verify resize happened
+	assert.InDelta(t, origWidth/2, img.Width(), 1)
+
+	// Verify the image is still exportable (all operations succeeded)
+	buf, meta, err := img.ExportJpeg(vips.NewJpegExportParams())
+	require.NoError(t, err)
+	assert.NotEmpty(t, buf)
+	assert.Equal(t, vips.ImageTypeJPEG, meta.Format)
+}
+
+func TestMultiStepPipeline_WithApplyNew(t *testing.T) {
+	require.NoError(t, vips.Startup(nil))
+
+	img, err := vips.NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer img.Close()
+
+	origWidth := img.Width()
+	origHeight := img.Height()
+
+	// Create two different outputs from the same source
+	thumbTransform := pipeline.Compose(
+		pipeline.Resize(0.25, vips.KernelLanczos3),
+		pipeline.Sharpen(0.5, 1.0, 2.0),
+	)
+
+	previewTransform := pipeline.Compose(
+		pipeline.Resize(0.5, vips.KernelLanczos3),
+	)
+
+	thumb, err := thumbTransform.ApplyNew(img)
+	require.NoError(t, err)
+	defer thumb.Close()
+
+	preview, err := previewTransform.ApplyNew(img)
+	require.NoError(t, err)
+	defer preview.Close()
+
+	// Original unchanged
+	assert.Equal(t, origWidth, img.Width())
+	assert.Equal(t, origHeight, img.Height())
+
+	// Thumb is 25%
+	assert.InDelta(t, origWidth/4, thumb.Width(), 1)
+
+	// Preview is 50%
+	assert.InDelta(t, origWidth/2, preview.Width(), 1)
+}


### PR DESCRIPTION
## Summary
- New `vips/pipeline` sub-package with a functional, composable API for image transforms
- Operations are values that compose into reusable Transform chains via `Compose()`
- `Apply()` mutates in place, `ApplyNew()` copies first
- `Process`/`ProcessBytes` convenience helpers for load+transform
- Export intentionally outside the pipeline for flexibility
- Error context includes step number and operation name

## Bug fixes included
- Fix `Recomb()` reading stale errors from vips error buffer (caused `TestRecomb_RGBA` flake)
- Fix test helpers (`goldenTest`, etc.) leaking VipsImage refs across tests

## Test plan
- [x] 16 pipeline tests covering composition, mutation, copy, error context, short-circuit
- [x] Multi-step integration tests with reusable presets and multiple outputs from same source
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add composable pipeline API for image transforms in `vips/pipeline`
> - Introduces a new `pipeline` package with `Composable`, `Operation`, and `Transform` types that allow chaining vips image operations in a functional style via [`pipeline.go`](https://github.com/davidbyttow/govips/pull/524/files#diff-93371523c8c8a0c560c8bb7f2dd9a4ded1d8d236977227cfec943b1d549cea73).
> - Adds factory functions in [`ops.go`](https://github.com/davidbyttow/govips/pull/524/files#diff-69140841e2c985caba7964f36fb9f418b88327f1493a0d430416d76d40ac1a85) wrapping existing `vips.ImageRef` methods (resize, crop, color, metadata, etc.) as reusable `Operation` values.
> - `Transform.Apply` mutates an image in place; `Transform.ApplyNew` returns a transformed copy; `Process` and `ProcessBytes` load from file or buffer and apply operations.
> - Errors include step index and operation name and wrap the underlying error for unwrapping.
> - Fixes `ImageRef.Recomb` to use `handleVipsError()` on nil `matrixImage` instead of reading `vips_error_buffer` directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98ac900.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->