### PR TITLE
Add NewImageFromHWCArray for load raw pixels

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -715,6 +715,34 @@ func NewImageFromGoImage(img image.Image) (*ImageRef, error) {
 	return newImageRef(vipsImage, ImageTypeUnknown, ImageTypeUnknown, nil), nil
 }
 
+// NewImageFromHWCArray creates a new ImageRef from a pixel data in HWC(height, width, channels) format.
+func NewImageFromHWCArray(pixels []byte, bands int, width, height int, bandFormat BandFormat, interpretation Interpretation) (*ImageRef, error) {
+	if err := startupIfNeeded(); err != nil {
+		return nil, err
+	}
+
+	// copy pixels
+	_pixels := make([]byte, len(pixels))
+	copy(_pixels, pixels)
+
+	vipsImage := C.create_image_from_memory_copy(
+		unsafe.Pointer(&_pixels[0]),
+		C.size_t(len(_pixels)),
+		C.int(width),
+		C.int(height),
+		C.int(bands),
+		C.VipsBandFormat(bandFormat),
+	)
+	runtime.KeepAlive(_pixels)
+	if vipsImage == nil {
+		return nil, errors.New("failed to create vips image from memory")
+	}
+
+	vipsImage.Type = C.VipsInterpretation(interpretation)
+
+	return newImageRef(vipsImage, ImageTypeUnknown, ImageTypeUnknown, _pixels), nil
+}
+
 func newImageRef(vipsImage *C.VipsImage, currentFormat ImageType, originalFormat ImageType, buf []byte) *ImageRef {
 	imageRef := &ImageRef{
 		image:          vipsImage,


### PR DESCRIPTION
Allow user to load raw pixels bytes buffer. Convenience for processing data from llm (i.e. onnxruntime) or other apis.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `NewImageFromHWCArray` to create a Vips image from raw pixel data
> Adds `NewImageFromHWCArray` in [vips/image.go](https://github.com/davidbyttow/govips/pull/526/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b) to construct an `ImageRef` from a caller-provided HWC-ordered byte slice. The function copies the input buffer, calls the C-level `create_image_from_memory_copy` with width, height, bands, and band format, sets the Vips interpretation, and returns an `ImageRef` with `ImageTypeUnknown` as the format. `runtime.KeepAlive` is used to prevent the copied buffer from being GC'd during the C call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11a7afc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->