### PR TITLE
detect BigTIFF image type

### DIFF
--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -216,9 +216,14 @@ func isPNG(buf []byte) bool {
 
 var tifII = []byte("\x49\x49\x2A\x00")
 var tifMM = []byte("\x4D\x4D\x00\x2A")
+var bigTifII = []byte("\x49\x49\x2B\x00")
+var bigTifMM = []byte("\x4D\x4D\x00\x2B")
 
 func isTIFF(buf []byte) bool {
-	return bytes.HasPrefix(buf, tifII) || bytes.HasPrefix(buf, tifMM)
+	return bytes.HasPrefix(buf, tifII) ||
+		bytes.HasPrefix(buf, tifMM) ||
+		bytes.HasPrefix(buf, bigTifII) ||
+		bytes.HasPrefix(buf, bigTifMM)
 }
 
 var webpHeader = []byte("\x57\x45\x42\x50")

--- a/vips/foreign_test.go
+++ b/vips/foreign_test.go
@@ -75,6 +75,18 @@ func Test_DetermineImageType__TIFF(t *testing.T) {
 	assert.Equal(t, ImageTypeTIFF, imageType)
 }
 
+func Test_DetermineImageType__BigTIFF(t *testing.T) {
+	for name, buf := range map[string][]byte{
+		"little_endian": {0x49, 0x49, 0x2B, 0x00, 0x08, 0x00, 0x00, 0x00, 0, 0, 0, 0},
+		"big_endian":    {0x4D, 0x4D, 0x00, 0x2B, 0x00, 0x08, 0x00, 0x00, 0, 0, 0, 0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			imageType := DetermineImageType(buf)
+			assert.Equal(t, ImageTypeTIFF, imageType)
+		})
+	}
+}
+
 func Test_DetermineImageType__WEBP(t *testing.T) {
 	require.NoError(t, Startup(&Config{}))
 


### PR DESCRIPTION
govips’ `DetermineImageType` recognized classic TIFF magic bytes but not BigTIFF magic bytes.

Since `LoadImageFromFile` routes through `LoadImageFromBuffer` and uses `DetermineImageType `before dispatching to libvips, BigTIFF inputs were rejected as unsupported image format even though libvips itself can load them. The fix adds BigTIFF little-endian and big-endian signatures to TIFF detection.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect BigTIFF image type in `isTIFF`
> Adds BigTIFF magic number detection to [`isTIFF`](https://github.com/davidbyttow/govips/pull/527/files#diff-ec94a2793e4149e5e3c5e926e52086a17d586f71fe03e67405c96512de0d6181) by checking for both little-endian (`0x49 0x49 0x2B 0x00`) and big-endian (`0x4D 0x4D 0x00 0x2B`) BigTIFF signatures alongside the existing standard TIFF checks. A new test in [`foreign_test.go`](https://github.com/davidbyttow/govips/pull/527/files#diff-ab13cb8efcc84796a5ccc8ad98f90acc662682b0d9c514b125120d461cfbdb10) verifies that `DetermineImageType` returns `ImageTypeTIFF` for both BigTIFF variants.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd3833c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->