### PR TITLE
Add NewImageFromMemory for raw pixel buffers

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -715,6 +715,70 @@ func NewImageFromGoImage(img image.Image) (*ImageRef, error) {
 	return newImageRef(vipsImage, ImageTypeUnknown, ImageTypeUnknown, nil), nil
 }
 
+// NewImageFromMemory creates a new ImageRef from a raw, uncompressed pixel
+// buffer. The buffer is interpreted as height rows of width pixels, each pixel
+// holding bands samples of the given BandFormat, laid out contiguously (no row
+// stride padding).
+//
+// Use this for raw byte arrays from sources like ML inference outputs (ONNX,
+// TensorFlow), camera sensors, or any in-memory pixel data. For Go's
+// image.Image, use NewImageFromGoImage. For compressed bytes (PNG, JPEG, etc.),
+// use NewImageFromBuffer.
+//
+// The pixel data is copied into libvips, so the caller is free to reuse or
+// free the input slice after this call returns.
+func NewImageFromMemory(pixels []byte, width, height, bands int, format BandFormat, interpretation Interpretation) (*ImageRef, error) {
+	if err := startupIfNeeded(); err != nil {
+		return nil, err
+	}
+
+	if width <= 0 || height <= 0 || bands <= 0 {
+		return nil, fmt.Errorf("invalid dimensions: width=%d height=%d bands=%d", width, height, bands)
+	}
+
+	bytesPerSample, ok := bandFormatSizes[format]
+	if !ok {
+		return nil, fmt.Errorf("unsupported band format: %d", format)
+	}
+
+	expected := width * height * bands * bytesPerSample
+	if len(pixels) != expected {
+		return nil, fmt.Errorf("pixel buffer size mismatch: got %d bytes, expected %d (%dx%dx%d samples of %d bytes)",
+			len(pixels), expected, width, height, bands, bytesPerSample)
+	}
+
+	vipsImage := C.create_image_from_memory_copy(
+		unsafe.Pointer(&pixels[0]),
+		C.size_t(len(pixels)),
+		C.int(width),
+		C.int(height),
+		C.int(bands),
+		C.VipsBandFormat(format),
+	)
+	runtime.KeepAlive(pixels)
+	if vipsImage == nil {
+		return nil, errors.New("failed to create vips image from memory")
+	}
+
+	vipsImage.Type = C.VipsInterpretation(interpretation)
+
+	return newImageRef(vipsImage, ImageTypeUnknown, ImageTypeUnknown, nil), nil
+}
+
+// bandFormatSizes is the byte size of one sample for each supported BandFormat.
+// Complex/DPComplex are excluded — vips_image_new_from_memory rejects them in
+// practice and the size depends on real/imag pairing semantics.
+var bandFormatSizes = map[BandFormat]int{
+	BandFormatUchar:  1,
+	BandFormatChar:   1,
+	BandFormatUshort: 2,
+	BandFormatShort:  2,
+	BandFormatUint:   4,
+	BandFormatInt:    4,
+	BandFormatFloat:  4,
+	BandFormatDouble: 8,
+}
+
 func newImageRef(vipsImage *C.VipsImage, currentFormat ImageType, originalFormat ImageType, buf []byte) *ImageRef {
 	imageRef := &ImageRef{
 		image:          vipsImage,

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -1603,6 +1603,105 @@ func TestNewImageFromGoImage_RGBA(t *testing.T) {
 	assert.Equal(t, 4, ref.Bands())
 }
 
+func TestNewImageFromMemory_RGB(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	// 2x2 RGB: red, green, blue, white.
+	pixels := []byte{
+		255, 0, 0, 0, 255, 0,
+		0, 0, 255, 255, 255, 255,
+	}
+
+	ref, err := NewImageFromMemory(pixels, 2, 2, 3, BandFormatUchar, InterpretationSRGB)
+	require.NoError(t, err)
+	defer ref.Close()
+
+	assert.Equal(t, 2, ref.Width())
+	assert.Equal(t, 2, ref.Height())
+	assert.Equal(t, 3, ref.Bands())
+	assert.Equal(t, BandFormatUchar, ref.BandFormat())
+	assert.Equal(t, InterpretationSRGB, ref.Interpretation())
+
+	tl, err := ref.GetPoint(0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []float64{255, 0, 0}, tl)
+
+	br, err := ref.GetPoint(1, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []float64{255, 255, 255}, br)
+}
+
+func TestNewImageFromMemory_Float(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	// 1x1 single-band float image holding the value 0.5.
+	pixels := make([]byte, 4)
+	bits := math.Float32bits(0.5)
+	pixels[0] = byte(bits)
+	pixels[1] = byte(bits >> 8)
+	pixels[2] = byte(bits >> 16)
+	pixels[3] = byte(bits >> 24)
+
+	ref, err := NewImageFromMemory(pixels, 1, 1, 1, BandFormatFloat, InterpretationBW)
+	require.NoError(t, err)
+	defer ref.Close()
+
+	assert.Equal(t, 1, ref.Width())
+	assert.Equal(t, 1, ref.Height())
+	assert.Equal(t, 1, ref.Bands())
+	assert.Equal(t, BandFormatFloat, ref.BandFormat())
+
+	// GetPoint hardcodes its sample count to 3/4 based on alpha presence, so
+	// only the first slot is meaningful for this 1-band image.
+	p, err := ref.GetPoint(0, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, p)
+	assert.InDelta(t, 0.5, p[0], 1e-6)
+}
+
+func TestNewImageFromMemory_BufferIsCopied(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	pixels := []byte{255, 0, 0, 0, 255, 0, 0, 0, 255, 128, 128, 128}
+
+	ref, err := NewImageFromMemory(pixels, 2, 2, 3, BandFormatUchar, InterpretationSRGB)
+	require.NoError(t, err)
+	defer ref.Close()
+
+	// Mutating the caller-side buffer must not affect the vips image.
+	for i := range pixels {
+		pixels[i] = 0
+	}
+
+	tl, err := ref.GetPoint(0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []float64{255, 0, 0}, tl)
+}
+
+func TestNewImageFromMemory_InvalidArgs(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	cases := []struct {
+		name   string
+		pixels []byte
+		w, h, b int
+		format BandFormat
+	}{
+		{"zero width", []byte{0}, 0, 1, 1, BandFormatUchar},
+		{"zero height", []byte{0}, 1, 0, 1, BandFormatUchar},
+		{"zero bands", []byte{0}, 1, 1, 0, BandFormatUchar},
+		{"size mismatch", []byte{0, 0, 0}, 2, 2, 3, BandFormatUchar},
+		{"unsupported format", make([]byte, 16), 1, 1, 1, BandFormatComplex},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, err := NewImageFromMemory(tc.pixels, tc.w, tc.h, tc.b, tc.format, InterpretationSRGB)
+			require.Error(t, err)
+			assert.Nil(t, ref)
+		})
+	}
+}
+
 func TestAutoRotate(t *testing.T) {
 	require.NoError(t, Startup(nil))
 


### PR DESCRIPTION
## Summary

Exposes `vips_image_new_from_memory_copy` through a Go-friendly API:

```go
ref, err := vips.NewImageFromMemory(pixels, width, height, bands, vips.BandFormatUchar, vips.InterpretationSRGB)
```

Fills the gap between `NewImageFromGoImage` (forces an `image.Image` / NRGBA boundary) and `NewImageFromBuffer` (encoded PNG/JPEG/etc.). Motivating use cases: raw pixel data from ML inference (ONNX, TensorFlow outputs), camera sensors, or any in-memory layout the caller can describe.

Closes #480. Also addresses the broader ask in #441 / #526.

## Behavior

- Up-front validation of dimensions, band format, and buffer length — callers get a clear Go error instead of a libvips crash.
- Pixel data is copied into libvips (`create_image_from_memory_copy`), so the input slice is safe to reuse or free immediately after the call returns.
- Supports all real BandFormats (uchar/char/ushort/short/uint/int/float/double). Complex/DPComplex are explicitly rejected — they're rarely useful here and the sample sizing is ambiguous.

## Test plan

- [x] `TestNewImageFromMemory_RGB` — 2x2 RGB round-trip, verifies width/height/bands/format/interpretation and corner pixel values.
- [x] `TestNewImageFromMemory_Float` — 1x1 single-band float image, verifies float decoding.
- [x] `TestNewImageFromMemory_BufferIsCopied` — mutates the caller-side slice after construction and confirms the vips image is unchanged.
- [x] `TestNewImageFromMemory_InvalidArgs` — zero width / zero height / zero bands / size mismatch / unsupported band format all return errors with no `ImageRef`.
- [x] Existing `TestNewImageFromGoImage*` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `NewImageFromMemory` to create a VipsImage from a raw pixel buffer
> - Adds `NewImageFromMemory` in [vips/image.go](https://github.com/davidbyttow/govips/pull/528/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b) that constructs an `ImageRef` from a contiguous, uncompressed pixel buffer given width, height, bands, `BandFormat`, and `VipsInterpretation`.
> - Validates dimensions, checks bytes-per-sample via a new `bandFormatSizes` map (complex formats unsupported), and verifies the buffer length matches the expected size before calling into libvips.
> - The input buffer is copied via `C.create_image_from_memory_copy`, so callers can safely mutate or reuse it after creation.
> - Tests cover RGB and float single-band images, buffer isolation, and all invalid-argument error paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ad97c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->