### PR TITLE
Fix input double-unref in Join (intermittent SIGSEGV)

### DIFF
--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -663,6 +663,39 @@ func TestImageRef_Join(t *testing.T) {
 	assert.True(t, height == image.Height(), "Join image height is incorrect: %d != %d", height, image.Height())
 }
 
+// TestImageRef_Join_InputsRetained guards the ownership contract for
+// Join: the input images are borrowed, not consumed. Join must not
+// unref them, so each input ImageRef must remain fully usable and
+// independently closable afterwards. Previously vipsJoin unref'd both
+// inputs, dropping references it never owned and leaving the inputs one
+// ref short — an intermittent use-after-free once the input ImageRefs
+// were later closed or finalized.
+func TestImageRef_Join_InputsRetained(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	before := OpenImageRefs()
+
+	image, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	joinImage, err := NewImageFromFile(resources + "jpg-24bit.jpg")
+	require.NoError(t, err)
+
+	require.NoError(t, image.Join(joinImage, DirectionHorizontal))
+
+	// The borrowed input must still be a live, usable image.
+	pt, err := joinImage.GetPoint(0, 0)
+	require.NoError(t, err)
+	assert.NotEmpty(t, pt)
+	_, _, err = joinImage.ExportNative()
+	require.NoError(t, err)
+
+	// And it must be independently closable without a double free.
+	joinImage.Close()
+	image.Close()
+
+	assert.Equal(t, before, OpenImageRefs(), "Join must not leak or over-release ImageRefs")
+}
+
 func TestImageRef_ArrayJoin(t *testing.T) {
 	require.NoError(t, Startup(nil))
 
@@ -1844,8 +1877,8 @@ func TestRotate_AllAngles(t *testing.T) {
 	require.NoError(t, Startup(nil))
 
 	tests := []struct {
-		angle       Angle
-		swapDims    bool
+		angle    Angle
+		swapDims bool
 	}{
 		{Angle0, false},
 		{Angle90, true},

--- a/vips/operations.go
+++ b/vips/operations.go
@@ -458,8 +458,11 @@ func vipsJoin(input1 *C.VipsImage, input2 *C.VipsImage, dir Direction) (*C.VipsI
 	incOpCounter("join")
 	var out *C.VipsImage
 
-	defer C.g_object_unref(C.gpointer(input1))
-	defer C.g_object_unref(C.gpointer(input2))
+	// NOTE: do NOT unref input1/input2 here. They are borrowed from the
+	// caller's ImageRefs, which own those references and unref them in
+	// Close/finalize. vips_join takes its own refs on its inputs for the
+	// lifetime of the output. Unref'ing here drops refs we never owned,
+	// which double-frees the inputs once their ImageRefs are collected.
 	if err := C.join(input1, input2, &out, C.int(dir)); err != 0 {
 		return nil, handleVipsError()
 	}


### PR DESCRIPTION
## Summary

`vipsJoin` unref'd its two input `VipsImage`s — references it borrowed from the caller's `ImageRef`s and never owned:

```go
defer C.g_object_unref(C.gpointer(input1))
defer C.g_object_unref(C.gpointer(input2))
```

`vips_join` takes its own refs on its inputs for the lifetime of the output, and the caller's `ImageRef`s own the refs they passed in (and drop them in `Close`/finalize). So the binding dropped two references it never owned — every `Join` left each input one ref short.

## Why it (intermittently) crashes

Nothing crashes at the call: the input usually stays alive on another reference (its `ImageRef`, or libvips' operation cache). The corruption surfaces **later and non-deterministically**, when a GC finalizer or an operation-cache eviction performs the *next* unref on the already-freed object — a double-free landing in libvips cache/dispose teardown:

```
g_type_check_instance_is_fundamentally_a   ← freed instance pointer
g_object_unref
vips_object_local_array_cb / vips_cache_free_cb
vips_cache_trim → vips_cache_operation_buildp → (some later, unrelated op)
```

This matches the long-standing intermittent SIGSEGV reports on macOS/Apple Silicon (wild / "pointer authentication failure" addresses, crash site wandering across `find_trim`/`heifsave`/`stats`/`jp2ksave`, bursty, never reproducible in isolation) — e.g. #356.

## How it was found

Running the test suite under Guard Malloc (`DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib`) turned the latent double-free into frequent traps. `GOGC=off` eliminated it (finalizer-timing dependent); disabling the operation cache made it *more* frequent (cache refs were masking the imbalance). An automated exclusion-bisection under `GOGC=5` isolated `TestImageRef_Join` as the unique culprit, and a minimal Join-plus-finalizer loop reproduced on demand — clean after removing the two unrefs.

Full investigation write-up: https://github.com/antst/govips/issues/1

## Change

- Remove the two erroneous input unrefs in `vipsJoin` (`vips_join` manages its own input refs).
- Add `TestImageRef_Join_InputsRetained`: after `Join`, both inputs must remain usable (`GetPoint`, `ExportNative`) and independently closable, with balanced `OpenImageRefs`.

`make test` passes; the change is a 2-line deletion plus a comment and a test.

## Note

This was found via `git grep g_object_unref` over the bindings: `vipsJoin` is the **only** place govips unref's a borrowed input `VipsImage` (every other op lets libvips manage input refs), so this is an isolated bug, not a pattern.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix double-unref of input images in `vipsJoin` causing intermittent SIGSEGV
> - Removes two erroneous `defer unref` calls on `input1` and `input2` in [vipsJoin](https://github.com/davidbyttow/govips/pull/531/files#diff-13ea1207a81e7461fcaf51a0379e2a383859b16a1891c1fe347a376871247578); `vips_join` borrows references and manages them for the lifetime of the output, so callers must not unref inputs.
> - Adds a test `TestImageRef_Join_InputsRetained` in [image_test.go](https://github.com/davidbyttow/govips/pull/531/files#diff-930ea3a5b231eeffb0834910ed13a448646dbf734958e2746eb33b769055ebe7) that verifies both inputs remain usable after `Join` and can be closed independently without a double free.
> - Behavioral Change: inputs to `Join` are no longer unref'd after the call, fixing use-after-free crashes that appeared intermittently under GC pressure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efc37e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->