### PR TITLE
Add TargetSize option to WebpExportParams

### DIFF
--- a/vips/foreign.c
+++ b/vips/foreign.c
@@ -310,6 +310,10 @@ int set_webpsave_options(VipsOperation *operation, SaveParams *params) {
     ret = vips_object_set(VIPS_OBJECT(operation), "Q", params->quality, NULL);
   }
 
+  if (!ret && params->webpTargetSize) {
+    ret = vips_object_set(VIPS_OBJECT(operation), "target_size", params->webpTargetSize, NULL);
+  }
+
   return ret;
 }
 
@@ -572,6 +576,7 @@ static SaveParams defaultSaveParams = {
     .webpKMax = 0,
     .webpKMin = 0,
     .webpMinSize = FALSE,
+    .webpTargetSize = 0,
 
     .heifBitdepth = 8,
     .heifLossless = FALSE,

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -446,7 +446,17 @@ func vipsSaveWebPToBuffer(in *C.VipsImage, params WebpExportParams) ([]byte, err
 	p.webpMinSize = C.int(boolToInt(params.MinSize))
 	p.webpKMin = C.int(params.MinKeyFrames)
 	p.webpKMax = C.int(params.MaxKeyFrames)
-	p.webpTargetSize = C.int(params.TargetSize)
+
+	if params.TargetSize > 0 {
+		// webpsave's "target_size" property was added in libvips 8.17.4; setting
+		// it on an older libvips fails at the C layer with an opaque "no property
+		// named `target_size'" error. Fail clearly instead.
+		if MajorVersion < 8 || (MajorVersion == 8 && MinorVersion < 17) ||
+			(MajorVersion == 8 && MinorVersion == 17 && MicroVersion < 4) {
+			return nil, fmt.Errorf("WebpExportParams.TargetSize requires libvips 8.17.4+, found %s", Version)
+		}
+		p.webpTargetSize = C.int(params.TargetSize)
+	}
 
 	if params.IccProfile != "" {
 		p.webpIccProfile = C.CString(params.IccProfile)

--- a/vips/foreign.go
+++ b/vips/foreign.go
@@ -446,6 +446,7 @@ func vipsSaveWebPToBuffer(in *C.VipsImage, params WebpExportParams) ([]byte, err
 	p.webpMinSize = C.int(boolToInt(params.MinSize))
 	p.webpKMin = C.int(params.MinKeyFrames)
 	p.webpKMax = C.int(params.MaxKeyFrames)
+	p.webpTargetSize = C.int(params.TargetSize)
 
 	if params.IccProfile != "" {
 		p.webpIccProfile = C.CString(params.IccProfile)

--- a/vips/foreign.h
+++ b/vips/foreign.h
@@ -113,6 +113,7 @@ typedef struct SaveParams {
   BOOL webpMinSize;
   int webpKMin;
   int webpKMax;
+  int webpTargetSize;
 
   // HEIF - https://github.com/libvips/libvips/blob/master/libvips/foreign/heifsave.c#L71
   int heifBitdepth; // Bitdepth to save at for >8 bit images

--- a/vips/image.go
+++ b/vips/image.go
@@ -297,6 +297,14 @@ type WebpExportParams struct {
 	MinSize         bool
 	MinKeyFrames    int
 	MaxKeyFrames    int
+	// TargetSize is the desired output size in bytes (libvips's webpsave
+	// "target_size" option, passed straight through to libwebp's own
+	// WebPConfig.target_size). When set (> 0), it takes precedence over
+	// Quality: libwebp runs its own internal search over the quality range,
+	// using more encoding passes, to produce output close to this size. It
+	// is a best effort: the resulting size may still land above or below
+	// the target. Leave at 0 (the default) to encode at Quality instead.
+	TargetSize int
 }
 
 // NewWebpExportParams creates default values for an export of a WEBP image.

--- a/vips/image.go
+++ b/vips/image.go
@@ -304,6 +304,9 @@ type WebpExportParams struct {
 	// using more encoding passes, to produce output close to this size. It
 	// is a best effort: the resulting size may still land above or below
 	// the target. Leave at 0 (the default) to encode at Quality instead.
+	//
+	// Requires libvips 8.17.4+ (when target_size was added to webpsave);
+	// ExportWebp returns an error if TargetSize is set on an older libvips.
 	TargetSize int
 }
 

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -110,6 +110,11 @@ func TestImageRef_WebP__NearLossless(t *testing.T) {
 func TestImageRef_WebP__TargetSize(t *testing.T) {
 	require.NoError(t, Startup(nil))
 
+	if MajorVersion < 8 || (MajorVersion == 8 && MinorVersion < 17) ||
+		(MajorVersion == 8 && MinorVersion == 17 && MicroVersion < 4) {
+		t.Skipf("webpsave target_size requires libvips 8.17.4+, found %s", Version)
+	}
+
 	srcBytes, err := os.ReadFile(resources + "png-24bit.png")
 	require.NoError(t, err)
 

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -107,6 +107,31 @@ func TestImageRef_WebP__NearLossless(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestImageRef_WebP__TargetSize(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	srcBytes, err := os.ReadFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+
+	src := bytes.NewReader(srcBytes)
+	img, err := NewImageFromReader(src)
+	require.NoError(t, err)
+	require.NotNil(t, img)
+
+	defaultOut, _, err := img.ExportWebp(NewWebpExportParams())
+	require.NoError(t, err)
+
+	// TargetSize asks libvips to search for a quality that lands near this
+	// budget instead of the default fixed Quality. Setting it well below the
+	// default-quality output size should shrink the result.
+	params := NewWebpExportParams()
+	params.TargetSize = len(defaultOut) / 4
+	targetOut, _, err := img.ExportWebp(params)
+	require.NoError(t, err)
+
+	assert.Less(t, len(targetOut), len(defaultOut))
+}
+
 func TestImageRef_PNG(t *testing.T) {
 	require.NoError(t, Startup(nil))
 


### PR DESCRIPTION
## Summary
- `vips_webpsave`/`webpsave_buffer` already expose a `target_size` property (desired output size in bytes), which libvips passes straight through to libwebp's own `WebPConfig.target_size` — libwebp itself runs the internal quality search to approach it, taking precedence over its `quality`/`compression` setting. `WebpExportParams`/`set_webpsave_options` never wire this up in govips, so `Quality` is currently the only way to influence WebP output size.
- Adds `WebpExportParams.TargetSize int`, threaded through `SaveParams.webpTargetSize` in the C bridge (`foreign.h`/`foreign.c`) and `vipsSaveWebPToBuffer` (`foreign.go`).
- Defaults to `0`, which preserves current behavior (encode at `Quality`).

## Test plan
- [x] `TestImageRef_WebP__TargetSize`: encodes a PNG fixture to WebP at default quality, then again with `TargetSize` set to a quarter of that size, and asserts the output actually shrinks.
- [x] `go build ./...` and `go test ./vips/... -run Webp` pass locally (libvips 8.18.3, macOS/arm64).
- Note: a full `go test ./vips/...` run segfaults in one unrelated test in this environment; verified the same crash reproduces on unmodified `master`, so it predates this change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `TargetSize` option to `WebpExportParams` for target output size
> - Adds a `TargetSize int` field to [`WebpExportParams`](https://github.com/davidbyttow/govips/pull/535/files#diff-e488e36196c25a401a5af66dd4e6010e8b4e2dec77d4eaba2b6c66fe86a3933b) that maps to the libvips `webpsave` `target_size` property, causing the encoder to search for a quality level that approximates the requested byte size.
> - When `TargetSize > 0`, [`vipsSaveWebPToBuffer`](https://github.com/davidbyttow/govips/pull/535/files#diff-ec94a2793e4149e5e3c5e926e52086a17d586f71fe03e67405c96512de0d6181) checks that the runtime libvips version is >= 8.17.4 and returns an error if not met.
> - Risk: `TargetSize` takes precedence over `Quality` when set, which is a behavioral change for callers that set both fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b6c9db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->