### PR TITLE
Expose image evaluation kill flag

### DIFF
--- a/vips/image.go
+++ b/vips/image.go
@@ -814,6 +814,16 @@ func (r *ImageRef) Close() {
 	r.lock.Unlock()
 }
 
+// SetKill sets the libvips kill flag used to stop image evaluation.
+func (r *ImageRef) SetKill(kill bool) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.image != nil {
+		C.vips_image_set_kill(r.image, toGboolean(kill))
+	}
+}
+
 // setImage resets the image for this image and frees the previous one
 func (r *ImageRef) setImage(image *C.VipsImage) {
 	r.lock.Lock()

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -599,6 +599,46 @@ func TestImageRef_Close__AlreadyClosed(t *testing.T) {
 	runtime.GC()
 }
 
+func TestImageRef_SetKill__SetBeforeExportStopsEvaluation(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	image, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer image.Close()
+
+	image.SetKill(true)
+
+	_, _, err = image.ExportWebp(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "killed")
+}
+
+func TestImageRef_SetKill__ClearsFlag(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	image, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer image.Close()
+
+	image.SetKill(true)
+	image.SetKill(false)
+
+	_, _, err = image.ExportWebp(nil)
+	require.NoError(t, err)
+}
+
+func TestImageRef_SetKill__ClosedImageIsNoOp(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	image, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	image.Close()
+
+	require.NotPanics(t, func() {
+		image.SetKill(true)
+	})
+}
+
 func TestImageRef_NotImage(t *testing.T) {
 	require.NoError(t, Startup(nil))
 


### PR DESCRIPTION
## Summary

- expose `ImageRef.SetKill(bool)` for cooperative cancellation of libvips evaluation
- serialize the signal with `Close` and treat an already closed image as a no-op
- leave image replacement semantics unchanged
- cover setting, clearing, and closed-image behavior

## Tests

- `go test -race -count=20 ./vips -run '^TestImageRef_SetKill'`
- `go test -count=1 -run '^$' ./...`
- `go vet ./...`

## Local full-suite note

On macOS with Go 1.26.4 and libvips 8.18.4, `go test -race -count=1 ./vips`
hits the same native crash on this branch and on unchanged current `master`
(`eec4bbd`). The targeted race tests, all-package compile gate, and vet gate
above pass.
