### PR TITLE
Fix background colors for 1/2-band greyscale images

### DIFF
--- a/vips/image_pixel.go
+++ b/vips/image_pixel.go
@@ -264,14 +264,10 @@ func (r *ImageRef) FindTrim(threshold float64, backgroundColor *Color) (int, int
 }
 
 // GetPoint reads a single pixel on an image.
-// The pixel values are returned in a slice of length n.
+// The pixel values are returned in a slice with one element per band.
 func (r *ImageRef) GetPoint(x int, y int) ([]float64, error) {
 	defer runtime.KeepAlive(r)
-	n := 3
-	if vipsHasAlpha(r.image) {
-		n = 4
-	}
-	return vipsGetPoint(r.image, n, x, y)
+	return vipsGetPoint(r.image, r.Bands(), x, y)
 }
 
 // Stats find many image statistics in a single pass through the data. Image is changed into a one-band

--- a/vips/image_test.go
+++ b/vips/image_test.go
@@ -766,6 +766,62 @@ func TestImageRef_Join_InputsRetained(t *testing.T) {
 	assert.Equal(t, before, OpenImageRefs(), "Join must not leak or over-release ImageRefs")
 }
 
+// https://github.com/davidbyttow/govips/issues/534
+func TestImageRef_EmbedBackgroundRGBA_GreyAlpha(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	image, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer image.Close()
+
+	require.NoError(t, image.ToColorSpace(InterpretationBW))
+	require.NoError(t, image.BandJoinConst([]float64{255}))
+	require.Equal(t, 2, image.Bands())
+
+	err = image.EmbedBackgroundRGBA(50, 50, 200, 200, &ColorRGBA{R: 165, A: 255})
+	require.NoError(t, err)
+
+	point, err := image.GetPoint(0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []float64{165, 255}, point)
+}
+
+func TestImageRef_EmbedBackground_Grey(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	image, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer image.Close()
+
+	require.NoError(t, image.ToColorSpace(InterpretationBW))
+	require.Equal(t, 1, image.Bands())
+
+	err = image.EmbedBackground(50, 50, 200, 200, &Color{R: 165})
+	require.NoError(t, err)
+
+	point, err := image.GetPoint(0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []float64{165}, point)
+}
+
+func TestImageRef_DrawRect_GreyAlpha(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	image, err := NewImageFromFile(resources + "png-24bit.png")
+	require.NoError(t, err)
+	defer image.Close()
+
+	require.NoError(t, image.ToColorSpace(InterpretationBW))
+	require.NoError(t, image.BandJoinConst([]float64{255}))
+
+	err = image.DrawRect(ColorRGBA{R: 128, A: 255}, 10, 10, 20, 20, true)
+	require.NoError(t, err)
+
+	point, err := image.GetPoint(15, 15)
+	require.NoError(t, err)
+	assert.Equal(t, []float64{128, 255}, point)
+}
+
 func TestImageRef_ArrayJoin(t *testing.T) {
 	require.NoError(t, Startup(nil))
 

--- a/vips/image_transform.go
+++ b/vips/image_transform.go
@@ -145,7 +145,8 @@ func (r *ImageRef) Embed(left, top, width, height int, extend ExtendStrategy) er
 	return nil
 }
 
-// EmbedBackground embeds the given picture with a background color
+// EmbedBackground embeds the given picture with a background color.
+// For greyscale images (1-2 bands) the R value is used as the grey level.
 func (r *ImageRef) EmbedBackground(left, top, width, height int, backgroundColor *Color) error {
 	defer runtime.KeepAlive(r)
 	c := &ColorRGBA{
@@ -170,7 +171,9 @@ func (r *ImageRef) EmbedBackground(left, top, width, height int, backgroundColor
 	return nil
 }
 
-// EmbedBackgroundRGBA embeds the given picture with a background rgba color
+// EmbedBackgroundRGBA embeds the given picture with a background rgba color.
+// For greyscale images the background is built from R and A only:
+// 1 band uses {R}, 2 bands (grey+alpha) use {R, A}.
 func (r *ImageRef) EmbedBackgroundRGBA(left, top, width, height int, backgroundColor *ColorRGBA) error {
 	defer runtime.KeepAlive(r)
 	if r.Height() > r.PageHeight() {

--- a/vips/operations.c
+++ b/vips/operations.c
@@ -59,6 +59,35 @@ int icc_transform(VipsImage *in, VipsImage **out, const char *output_profile, co
 
 // Conversion
 
+// background_for_bands fills vec with a background vector sized to the
+// image's band count and returns the element count; libvips rejects
+// vectors longer than the band count (e.g. "linear: vector must have 1
+// or 2 elements" for greyscale images). Greyscale images take the R
+// value as the grey level: 1 band -> {r}, 2 bands -> {r, a}.
+static int background_for_bands(VipsImage *in, double vec[4], double r,
+                                double g, double b, double a) {
+  switch (in->Bands) {
+  case 1:
+    vec[0] = r;
+    return 1;
+  case 2:
+    vec[0] = r;
+    vec[1] = a;
+    return 2;
+  case 3:
+    vec[0] = r;
+    vec[1] = g;
+    vec[2] = b;
+    return 3;
+  default:
+    vec[0] = r;
+    vec[1] = g;
+    vec[2] = b;
+    vec[3] = a;
+    return 4;
+  }
+}
+
 int embed_image(VipsImage *in, VipsImage **out, int left, int top, int width,
                 int height, int extend) {
   return vips_embed(in, out, left, top, width, height, "extend", extend, NULL);
@@ -67,16 +96,9 @@ int embed_image(VipsImage *in, VipsImage **out, int left, int top, int width,
 int embed_image_background(VipsImage *in, VipsImage **out, int left, int top, int width,
                 int height, double r, double g, double b, double a) {
 
-  double background[3] = {r, g, b};
-  double backgroundRGBA[4] = {r, g, b, a};
-
-  VipsArrayDouble *vipsBackground;
-
-  if (in->Bands <= 3) {
-    vipsBackground = vips_array_double_new(background, 3);
-  } else {
-    vipsBackground = vips_array_double_new(backgroundRGBA, 4);
-  }
+  double background[4];
+  int n = background_for_bands(in, background, r, g, b, a);
+  VipsArrayDouble *vipsBackground = vips_array_double_new(background, n);
 
   int code = vips_embed(in, out, left, top, width, height,
     "extend", VIPS_EXTEND_BACKGROUND, "background", vipsBackground, NULL);
@@ -122,16 +144,10 @@ int embed_multi_page_image(VipsImage *in, VipsImage **out, int left, int top, in
 
 int embed_multi_page_image_background(VipsImage *in, VipsImage **out, int left, int top, int width,
                                    int height, double r, double g, double b, double a) {
-  double background[3] = {r, g, b};
-  double backgroundRGBA[4] = {r, g, b, a};
+  double background[4];
+  int n = background_for_bands(in, background, r, g, b, a);
+  VipsArrayDouble *vipsBackground = vips_array_double_new(background, n);
 
-  VipsArrayDouble *vipsBackground;
-
-  if (in->Bands <= 3) {
-    vipsBackground = vips_array_double_new(background, 3);
-  } else {
-    vipsBackground = vips_array_double_new(backgroundRGBA, 4);
-  }
   VipsObject *base = VIPS_OBJECT(vips_image_new());
   int page_height = vips_image_get_page_height(in);
   int in_width = in->Xsize;
@@ -180,17 +196,9 @@ int similarity(VipsImage *in, VipsImage **out, double scale, double angle,
     a = 65535 * a / 255;
   }
 
-  double background[3] = {r, g, b};
-  double backgroundRGBA[4] = {r, g, b, a};
-
-  VipsArrayDouble *vipsBackground;
-
-  // Ignore the alpha channel if the image doesn't have one
-  if (in->Bands <= 3) {
-    vipsBackground = vips_array_double_new(background, 3);
-  } else {
-    vipsBackground = vips_array_double_new(backgroundRGBA, 4);
-  }
+  double background[4];
+  int n = background_for_bands(in, background, r, g, b, a);
+  VipsArrayDouble *vipsBackground = vips_array_double_new(background, n);
 
   int code = vips_similarity(in, out, "scale", scale, "angle", angle,
                              "background", vipsBackground, "idx", idx, "idy",
@@ -283,16 +291,10 @@ int draw_rect(VipsImage *in, double r, double g, double b, double a, int left,
     a = 65535 * a / 255;
   }
 
-  double background[3] = {r, g, b};
-  double backgroundRGBA[4] = {r, g, b, a};
-
-  if (in->Bands <= 3) {
-    return vips_draw_rect(in, background, 3, left, top, width, height, "fill",
-                          fill, NULL);
-  } else {
-    return vips_draw_rect(in, backgroundRGBA, 4, left, top, width, height,
-                          "fill", fill, NULL);
-  }
+  double ink[4];
+  int n = background_for_bands(in, ink, r, g, b, a);
+  return vips_draw_rect(in, ink, n, left, top, width, height, "fill", fill,
+                        NULL);
 }
 
 // Header

--- a/vips/operations.go
+++ b/vips/operations.go
@@ -37,7 +37,7 @@ func vipsGetPoint(in *C.VipsImage, n int, x int, y int) ([]float64, error) {
 
 	// Copy from C memory into a Go slice, then free the C allocation.
 	result := make([]float64, n)
-	copy(result, (*[4]float64)(unsafe.Pointer(out))[:n:n])
+	copy(result, unsafe.Slice((*float64)(unsafe.Pointer(out)), n))
 	gFreePointer(unsafe.Pointer(out))
 	return result, nil
 }


### PR DESCRIPTION
## Summary

- `EmbedBackground`, `EmbedBackgroundRGBA`, `Similarity`, and `DrawRect` always built a 3- or 4-element background vector (`Bands <= 3 ? 3 : 4` in `operations.c`), which libvips rejects for greyscale images: `linear: vector must have 1 or 2 elements`. A shared `background_for_bands` helper now sizes the vector to the image's band count, with the R value doubling as the grey level: 1 band -> `{r}`, 2 bands (grey+alpha) -> `{r, a}`. 3/4+-band behavior is unchanged.
- `GetPoint` had the same hardcoded 3-or-4 assumption and returned trailing garbage elements for greyscale images (and truncated images with more than 4 bands). It now returns exactly one element per band, and the C-to-Go copy uses `unsafe.Slice` instead of a `[4]float64` cast so band counts above 4 can't overrun.

Out of scope, same latent class (noting for a follow-up): `find_trim` hardcodes a 3-element background, and `Flatten` always sends a 3-element background via the generated bindings.

## Tests

- `TestImageRef_EmbedBackgroundRGBA_GreyAlpha` — the exact repro from #534 (2-band grey+alpha, background `{165, 255}`); failed with the reported error before the fix.
- `TestImageRef_EmbedBackground_Grey` — 1-band case; before the fix this silently produced a corrupt result rather than erroring.
- `TestImageRef_DrawRect_GreyAlpha` — same class in the draw path.
- Full `go test ./vips` locally: only the 4 known environmental HEIC failures (missing x265 dylib on this machine), identical to unmodified master.

Fixes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix background colors for 1/2-band greyscale images in embed, similarity, and draw operations
> - Introduces `background_for_bands` in [operations.c](https://github.com/davidbyttow/govips/pull/538/files#diff-b93d0f6a9f0254f2e294979210a7a37493d66009497deee8f19dabd58a80c7af), a helper that builds a background/ink vector sized to the image's band count: `{r}` for 1-band, `{r,a}` for 2-band, `{r,g,b}` for 3-band, and `{r,g,b,a}` for 4+ bands.
> - Applies this helper to `embed_image_background`, `embed_multi_page_image_background`, `similarity`, and `draw_rect`, replacing hardcoded 3/4-element arrays.
> - Fixes `ImageRef.GetPoint` in [image_pixel.go](https://github.com/davidbyttow/govips/pull/538/files#diff-c8d930dc147921b711478df2c595ababbe2668169248e5df14e9caf8f97b9c73) and `vipsGetPoint` in [operations.go](https://github.com/davidbyttow/govips/pull/538/files#diff-13ea1207a81e7461fcaf51a0379e2a383859b16a1891c1fe347a376871247578) to return one value per band instead of always 3 or 4.
> - Adds tests for greyscale and greyscale+alpha embed and draw operations to verify correct pixel values and slice length.
> - Behavioral Change: `GetPoint` now returns a slice with length equal to `Bands()` — callers assuming a fixed length of 3 or 4 will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97cddf5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->