### PR TITLE
Sniff stream signature to preserve sub-format detection

### DIFF
--- a/vips/stream.c
+++ b/vips/stream.c
@@ -1,5 +1,7 @@
 #include "stream.h"
 
+#include <string.h>
+
 // Option setters shared with the buffer path, defined in foreign.c.
 // Reusing them keeps streaming output identical to the buffer output.
 extern int set_jpegload_options(VipsOperation *operation, LoadParams *params);
@@ -76,6 +78,15 @@ VipsTargetCustom *create_target_custom(int handle) {
                    GINT_TO_POINTER(handle));
 
   return target;
+}
+
+int source_sniff_header(VipsSourceCustom *source, unsigned char *out, int len) {
+  const unsigned char *p = vips_source_sniff(VIPS_SOURCE(source), (size_t) len);
+  if (!p) {
+    return -1;
+  }
+  memcpy(out, p, (size_t) len);
+  return 0;
 }
 
 static ImageType image_type_for_loader(const char *name) {

--- a/vips/stream.go
+++ b/vips/stream.go
@@ -521,6 +521,13 @@ func LoadImageFromReader(r io.Reader, params *ImportParams) (*ImageRef, error) {
 		return nil, handleVipsError()
 	}
 
+	// Sniff the signature up front (buffered and rewound, not consumed):
+	// the loader nickname alone cannot express sub-formats — AVIF loads
+	// via heifload, BMP/PSD via magickload — but the buffer path reports
+	// them via DetermineImageType, and the streaming path must match.
+	var header [12]byte
+	headerKnown := C.source_sniff_header(source, (*C.uchar)(unsafe.Pointer(&header[0])), C.int(len(header))) == 0
+
 	loadParams := createImportParams(ImageTypeUnknown, params)
 
 	if code := C.load_from_source(source, &loadParams); code != 0 {
@@ -532,9 +539,18 @@ func LoadImageFromReader(r io.Reader, params *ImportParams) (*ImageRef, error) {
 
 	lazy := loadParams.outputImage
 	format := ImageType(loadParams.inputFormat)
+	originalFormat := format
+	if headerKnown && (format == ImageTypeHEIF || format == ImageTypeMagick) {
+		if sniffed := DetermineImageType(header[:]); sniffed != ImageTypeUnknown {
+			originalFormat = sniffed
+			if !isNeedToChangeLoaderToMagick(sniffed) {
+				format = sniffed
+			}
+		}
+	}
 
 	if sequentialAccess(params) {
-		ref := newImageRef(lazy, format, format, nil)
+		ref := newImageRef(lazy, format, originalFormat, nil)
 		ref.streamSource = &streamSourceRef{handle: handle, entry: entry, source: source}
 		govipsLog("govips", LogLevelDebug, fmt.Sprintf("created sequential imageRef %p from reader", ref))
 		return ref, nil
@@ -551,7 +567,7 @@ func LoadImageFromReader(r io.Reader, params *ImportParams) (*ImageRef, error) {
 		return nil, wrapStreamError("streaming load", err, entry.takeErr())
 	}
 
-	ref := newImageRef(out, format, format, nil)
+	ref := newImageRef(out, format, originalFormat, nil)
 	govipsLog("govips", LogLevelDebug, fmt.Sprintf("created imageRef %p from reader", ref))
 	return ref, nil
 }

--- a/vips/stream.h
+++ b/vips/stream.h
@@ -72,6 +72,12 @@ int save_webp_to_target(SaveParams *params, VipsTargetCustom *target);
 int save_heif_to_target(SaveParams *params, VipsTargetCustom *target);
 int save_gif_to_target(SaveParams *params, VipsTargetCustom *target);
 
+// Copies the first len bytes of the source into out without consuming
+// them (vips_source_sniff buffers and rewinds). Returns non-zero if the
+// stream is shorter than len or unreadable. Call before loading so the
+// sniff window is still rewindable for every source kind.
+int source_sniff_header(VipsSourceCustom *source, unsigned char *out, int len);
+
 // Unrefs *source / *target and sets it to NULL. NULL-safe.
 void clear_source(VipsSourceCustom **source);
 void clear_target(VipsTargetCustom **target);

--- a/vips/stream_test.go
+++ b/vips/stream_test.go
@@ -404,6 +404,38 @@ func TestSaveToWriter_ByteIdenticalToExport(t *testing.T) {
 	assert.Zero(t, targets, "all targets must be deregistered after save")
 }
 
+// TestLoadImageFromReader_SubFormatDetection: the loader nickname alone
+// cannot express sub-formats (AVIF loads via heifload, BMP/PSD via
+// magickload), so the streaming path sniffs the signature and must
+// report the same Format/OriginalFormat as the buffer path.
+func TestLoadImageFromReader_SubFormatDetection(t *testing.T) {
+	require.NoError(t, Startup(nil))
+
+	for _, file := range []string{"avif-8bit.avif", "bmp.bmp", "psd.example.psd"} {
+		t.Run(file, func(t *testing.T) {
+			buf, err := os.ReadFile(resources + file)
+			require.NoError(t, err)
+
+			fromBuffer, err := LoadImageFromBuffer(buf, nil)
+			if err != nil {
+				t.Skipf("buffer load failed (environment lacks codec): %v", err)
+			}
+			defer fromBuffer.Close()
+
+			fromReader, err := LoadImageFromReader(bytes.NewReader(buf), nil)
+			if err != nil {
+				t.Skipf("no source loader for this format in this libvips build: %v", err)
+			}
+			defer fromReader.Close()
+
+			assert.Equal(t, fromBuffer.Format(), fromReader.Format(),
+				"streaming Format must match the buffer path")
+			assert.Equal(t, fromBuffer.OriginalFormat(), fromReader.OriginalFormat(),
+				"streaming OriginalFormat must match the buffer path")
+		})
+	}
+}
+
 // TestSaveToWriterTyped_ByteIdenticalToExport exercises format-specific
 // options that the generic SaveToWriter/ExportParams path cannot express,
 // verifying the typed savers stay byte-identical to their Export*


### PR DESCRIPTION
## Summary

Follow-up to #539, fixing the issue Macroscope flagged there: the streaming load derived the image type from the loader nickname alone, so AVIF (via `heifload_source`) reported `ImageTypeHEIF`, and BMP/PSD (via `magickload_source`) reported `ImageTypeMagick` with the original format lost. The buffer path detects these from the file signature — and `ExportNative` on a streamed AVIF would have picked the HEIC encoder.

Fix: sniff the first 12 bytes before loading (`vips_source_sniff` buffers and rewinds, so nothing is consumed, and it works for every source kind at that point) and refine the ambiguous HEIF/MAGICK loader types through the existing `DetermineImageType`, mirroring `vipsLoadFromBuffer`'s current/original format split exactly.

## Tests

- New `TestLoadImageFromReader_SubFormatDetection`: for `avif-8bit.avif`, `bmp.bmp`, and `psd.example.psd`, streaming `Format()`/`OriginalFormat()` must equal the buffer path's. BMP/PSD verified locally; AVIF exercises on CI (local HEIF module is broken — missing libx265).
- Full streaming suite locally: identical results to the pre-change baseline (only the known environmental HEIC failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sniff stream signature to preserve sub-format detection in `LoadImageFromReader`
> - Adds a `source_sniff_header` C helper in [stream.c](https://github.com/davidbyttow/govips/pull/540/files#diff-7f1119c5fa2c3cebe66c760741044738842549540b65eb4ad3584aa7bd81cb9c) that reads up to N bytes from a `VipsSourceCustom` without consuming the stream, using `vips_source_sniff` and `memcpy`.
> - `LoadImageFromReader` in [stream.go](https://github.com/davidbyttow/govips/pull/540/files#diff-8b8d8c625a3ff3409bcda9d8449cefe6172d8f1bd699cd7efa930ecf897dd35c) now sniffs up to 12 bytes before loading, then uses `DetermineImageType` to refine `OriginalFormat` when the loader reports HEIF or Magick (e.g. resolving to AVIF, BMP, or PSD).
> - `Format` is also set to the sniffed sub-format when the detected type does not require Magick, matching the behavior of `LoadImageFromBuffer`.
> - A new test in [stream_test.go](https://github.com/davidbyttow/govips/pull/540/files#diff-6085ddfbec51f455ad06fd9d3a4eed96301cc3a34e643df2694bf39824068305) asserts that `Format` and `OriginalFormat` agree between the buffer and reader load paths for AVIF, BMP, and PSD inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14a9aee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->