### PR TITLE
Correct AGENTS.md on ImageRef locking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ resources/            test fixtures + golden files
 examples/             runnable examples (separate go modules)
 ```
 
-`ImageRef` is a mutable handle: operations replace the underlying `VipsImage` via `setImage` (which unrefs the old one). `Close` and a GC finalizer release the ref; methods guard with `runtime.KeepAlive(r)` and `r.lock`.
+`ImageRef` is a mutable handle: operations replace the underlying `VipsImage` via `setImage` (which unrefs the old one). `Close` and a GC finalizer release the ref. `r.lock` guards only lifecycle/ownership transitions (`Close`, `SetKill`, `setImage`, streaming materialize/save); ordinary transform/export/metadata methods take no lock, just `runtime.KeepAlive(r)`, so an `ImageRef` is NOT safe for concurrent use. Never call methods (including `Close`) on the same `ImageRef` from multiple goroutines.
 
 ## cgo and memory rules
 


### PR DESCRIPTION
## Summary

Fixes the inaccuracy Macroscope flagged on #541: AGENTS.md said ImageRef methods "guard with `runtime.KeepAlive(r)` and `r.lock`", implying general concurrency safety. In reality `r.lock` is taken only at lifecycle/ownership transitions (`Close`, `SetKill`, `setImage`, streaming materialize/save — verified via grep, those are the only five `r.lock.Lock()` sites); ordinary transform/export/metadata methods take no lock. The doc now says that plainly and warns against using one `ImageRef` from multiple goroutines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct `ImageRef` locking and concurrency documentation in AGENTS.md
> Updates [AGENTS.md](https://github.com/davidbyttow/govips/pull/542/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to accurately describe `ImageRef` concurrency semantics. Clarifies that `r.lock` guards only lifecycle/ownership transitions (`Close`, `SetKill`, `setImage`, streaming materialize/save), while ordinary transform, export, and metadata methods do not take the lock and rely solely on `runtime.KeepAlive(r)`. Explicitly documents that `ImageRef` is not safe for concurrent use and that no methods, including `Close`, may be called from multiple goroutines simultaneously.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54f71e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->