### PR TITLE
Add runtime.KeepAlive for ImageRef arguments in two-image ops

### DIFF
--- a/vips/image_composite.go
+++ b/vips/image_composite.go
@@ -8,6 +8,7 @@ import "runtime"
 // CompositeMulti composites the given overlay image on top of the associated image with provided blending mode.
 func (r *ImageRef) CompositeMulti(ins []*ImageComposite) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(ins)
 	out, err := vipsComposite(toVipsCompositeStructs(r, ins))
 	if err != nil {
 		return err
@@ -19,6 +20,7 @@ func (r *ImageRef) CompositeMulti(ins []*ImageComposite) error {
 // Composite composites the given overlay image on top of the associated image with provided blending mode.
 func (r *ImageRef) Composite(overlay *ImageRef, mode BlendMode, x, y int) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(overlay)
 	out, err := vipsGenComposite2(r.image, overlay.image, mode, &Composite2Options{X: &x, Y: &y})
 	if err != nil {
 		return err
@@ -30,6 +32,7 @@ func (r *ImageRef) Composite(overlay *ImageRef, mode BlendMode, x, y int) error 
 // Insert draws the image on top of the associated image at the given coordinates.
 func (r *ImageRef) Insert(sub *ImageRef, x, y int, expand bool, background *ColorRGBA) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(sub)
 	insertOpts := &InsertOptions{Expand: &expand}
 	if background != nil {
 		insertOpts.Background = []float64{float64(background.R), float64(background.G), float64(background.B), float64(background.A)}
@@ -45,6 +48,7 @@ func (r *ImageRef) Insert(sub *ImageRef, x, y int, expand bool, background *Colo
 // Join joins this image with another in the direction specified
 func (r *ImageRef) Join(in *ImageRef, dir Direction) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(in)
 	out, err := vipsJoin(r.image, in.image, dir)
 	if err != nil {
 		return err
@@ -56,6 +60,7 @@ func (r *ImageRef) Join(in *ImageRef, dir Direction) error {
 // ArrayJoin joins an array of images together wrapping at each n images
 func (r *ImageRef) ArrayJoin(images []*ImageRef, across int) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(images)
 	allImages := append([]*ImageRef{r}, images...)
 	inputs := make([]*C.VipsImage, len(allImages))
 	for i := range inputs {

--- a/vips/image_pixel.go
+++ b/vips/image_pixel.go
@@ -68,6 +68,7 @@ func (r *ImageRef) Rank(width int, height int, index int) error {
 // Mapim resamples an image using index to look up pixels
 func (r *ImageRef) Mapim(index *ImageRef) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(index)
 	out, err := vipsGenMapim(r.image, index.image, nil)
 	if err != nil {
 		return err
@@ -79,6 +80,7 @@ func (r *ImageRef) Mapim(index *ImageRef) error {
 // Maplut maps an image through another image acting as a LUT (Look Up Table)
 func (r *ImageRef) Maplut(lut *ImageRef) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(lut)
 	out, err := vipsGenMaplut(r.image, lut.image, nil)
 	if err != nil {
 		return err
@@ -111,6 +113,7 @@ func (r *ImageRef) ExtractBandToImage(band int, num int) (*ImageRef, error) {
 // BandJoin joins a set of images together, bandwise.
 func (r *ImageRef) BandJoin(images ...*ImageRef) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(images)
 	vipsImages := []*C.VipsImage{r.image}
 	for _, vipsImage := range images {
 		vipsImages = append(vipsImages, vipsImage.image)
@@ -216,6 +219,7 @@ func (r *ImageRef) UnpremultiplyAlpha() error {
 // Add calculates a sum of the image + addend and stores it back in the image
 func (r *ImageRef) Add(addend *ImageRef) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(addend)
 	out, err := vipsGenAdd(r.image, addend.image)
 	if err != nil {
 		return err
@@ -227,6 +231,7 @@ func (r *ImageRef) Add(addend *ImageRef) error {
 // Multiply calculates the product of the image * multiplier and stores it back in the image
 func (r *ImageRef) Multiply(multiplier *ImageRef) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(multiplier)
 	out, err := vipsGenMultiply(r.image, multiplier.image)
 	if err != nil {
 		return err
@@ -238,6 +243,7 @@ func (r *ImageRef) Multiply(multiplier *ImageRef) error {
 // Divide calculates the product of the image / denominator and stores it back in the image
 func (r *ImageRef) Divide(denominator *ImageRef) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(denominator)
 	out, err := vipsGenDivide(r.image, denominator.image)
 	if err != nil {
 		return err
@@ -347,6 +353,7 @@ func (r *ImageRef) DrawRect(ink ColorRGBA, left int, top int, width int, height 
 // Subtract calculate subtract operation between two images.
 func (r *ImageRef) Subtract(in2 *ImageRef) error {
 	defer runtime.KeepAlive(r)
+	defer runtime.KeepAlive(in2)
 	out, err := vipsGenSubtract(r.image, in2.image)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

`ImageRef` carries a finalizer that unrefs the underlying `VipsImage`:

```go
runtime.SetFinalizer(imageRef, finalizeImage)   // -> ref.Close() -> g_object_unref
```

The two-image methods already guard the **receiver** with `defer runtime.KeepAlive(r)`, but not the `*ImageRef` they take as an **argument**. Once the callee has loaded `arg.image`, nothing in Go refers to `arg` any more, so the GC is free to finalize it — dropping the `VipsImage` reference while the cgo call is still using that pointer. This is exactly the case [`runtime.KeepAlive`'s documentation](https://pkg.go.dev/runtime#KeepAlive) describes.

It's reachable from ordinary code whenever the argument's last reference is the call expression itself:

```go
base.Composite(loadOverlay(), BlendModeOver, 0, 0)
```

The receiver and the argument are exposed to the same hazard, so this guards both. Twelve sites:

| file | methods |
|---|---|
| `image_pixel.go` | `Mapim`, `Maplut`, `BandJoin`, `Add`, `Multiply`, `Divide`, `Subtract` |
| `image_composite.go` | `CompositeMulti`, `Composite`, `Insert`, `Join`, `ArrayJoin` |

## Honest scope

**I could not reproduce a crash from this.** I ran a targeted loop (argument deliberately unreachable during the call, sibling goroutine spinning `runtime.GC()`, `GOGC=5`, Guard Malloc) for 400 iterations with no fault. The window between the Go-side field load and libvips taking its own ref is a handful of instructions, so that's expected — this is a latent hazard, not a demonstrated failure.

I'm raising it as a consistency fix rather than a bug fix: the receiver-side `KeepAlive` calls already in these functions imply the hazard is understood, and the argument is the same hazard left unguarded. Zero behavior change, and no cost — `KeepAlive` emits no instructions, it only extends the liveness range the compiler must honor.

## Related

`fix/keepalive-cgo` (yours, Feb) does the receiver side in `image.go` and is still unmerged. The two don't overlap — that branch covers `Bands()`, `ColorSpace()`, `ImageFields()` and friends in `image.go`; this covers argument positions in `image_pixel.go` / `image_composite.go`. Happy to fold that branch in here and send a single complete pass instead, if you'd prefer.

I also have an env-gated stress harness (`GOVIPS_STRESS=1`) left over from the #531 investigation — the Guard Malloc / `GOGC` rig that isolated the `Join` double-unref. Glad to add it in a separate PR if it'd be useful; leaving it out here to keep this reviewable.

## Verification

`go build ./...`, `go vet ./vips/`, and the full `go test ./vips/` suite pass on macOS arm64 / libvips 8.18.4. `gofmt` clean (the two pre-existing unformatted files, `generated.go` and `image_test.go`, are untouched).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `runtime.KeepAlive` for secondary `ImageRef` arguments in multi-image operations
> Without `runtime.KeepAlive`, the Go GC can finalize `ImageRef` arguments before a CGo call completes, causing use-after-free bugs. Adds `defer runtime.KeepAlive(...)` for every secondary image argument in [image_composite.go](https://github.com/davidbyttow/govips/pull/543/files#diff-d28522bd51ae2b70c3bbbdcfdcba392aa58c7b7f004518f0e707749b33105721) and [image_pixel.go](https://github.com/davidbyttow/govips/pull/543/files#diff-c8d930dc147921b711478df2c595ababbe2668169248e5df14e9caf8f97b9c73), covering `Composite`, `CompositeMulti`, `Insert`, `Join`, `ArrayJoin`, `Mapim`, `Maplut`, `BandJoin`, `Add`, `Multiply`, `Divide`, and `Subtract`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 448398a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->